### PR TITLE
Feature: mocked requests

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -362,12 +362,12 @@
 			isa = PBXGroup;
 			children = (
 				D5B965321C922C500099D2F9 /* ContentTypeSpec.swift */,
+				D527ED981C9B84A20092AD6B /* MethodSpec.swift */,
 				DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */,
 				D5B965331C922C500099D2F9 /* SessionConfigurationSpec.swift */,
 				D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */,
 				D5B964F81C9216FD0099D2F9 /* MessageSpec.swift */,
 				D5B964FB1C9217140099D2F9 /* RequestableSpec.swift */,
-				D527ED981C9B84A20092AD6B /* MethodSpec.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -91,6 +91,14 @@
 		DAA50FF21C97738400D01F78 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF01C97738400D01F78 /* Header.swift */; };
 		DAA50FF41C9786BE00D01F78 /* HeaderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */; };
 		DAA50FF51C9786BE00D01F78 /* HeaderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */; };
+		DAA50FF81C9A1E8800D01F78 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */; };
+		DAA50FF91C9A1E8800D01F78 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */; };
+		DAA50FFB1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */; };
+		DAA50FFC1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */; };
+		DAA510021C9A2D3C00D01F78 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* MockRequest.swift */; };
+		DAA510031C9A2D3C00D01F78 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* MockRequest.swift */; };
+		DAA510051C9A2D5800D01F78 /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510041C9A2D5800D01F78 /* MockDataTask.swift */; };
+		DAA510061C9A2D5800D01F78 /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510041C9A2D5800D01F78 /* MockDataTask.swift */; };
 		DAC92A061C7F90B400F01940 /* Malibu.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC92A051C7F90B400F01940 /* Malibu.swift */; };
 		DAC92A071C7F90B400F01940 /* Malibu.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC92A051C7F90B400F01940 /* Malibu.swift */; };
 		DAC92A091C7F961900F01940 /* FormURLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC92A081C7F961900F01940 /* FormURLEncoder.swift */; };
@@ -185,6 +193,10 @@
 		DA5B4D0E1C8E5A07004E21ED /* NetworkingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingSpec.swift; sourceTree = "<group>"; };
 		DAA50FF01C97738400D01F78 /* Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderSpec.swift; sourceTree = "<group>"; };
+		DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTask.swift; sourceTree = "<group>"; };
+		DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunning.swift; sourceTree = "<group>"; };
+		DAA510011C9A2D3C00D01F78 /* MockRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequest.swift; sourceTree = "<group>"; };
+		DAA510041C9A2D5800D01F78 /* MockDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataTask.swift; sourceTree = "<group>"; };
 		DAC92A051C7F90B400F01940 /* Malibu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Malibu.swift; sourceTree = "<group>"; };
 		DAC92A081C7F961900F01940 /* FormURLEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormURLEncoder.swift; sourceTree = "<group>"; };
 		DAC92A0B1C7FA5E700F01940 /* FormURLEncoderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormURLEncoderSpec.swift; sourceTree = "<group>"; };
@@ -364,6 +376,8 @@
 				DAEE2BAC1C7F8A770000FB12 /* Encoding */,
 				DAC92A341C87B8F300F01940 /* Validation */,
 				D503D38B1C8DA6CF0009BDAD /* Serialization */,
+				DAA50FF61C9A1D8800D01F78 /* Tasks */,
+				DAA510001C9A2D2000D01F78 /* Mocks */,
 				D5B964F01C92119D0099D2F9 /* Request */,
 				D5B965151C922BDC0099D2F9 /* Response */,
 				DAC92A051C7F90B400F01940 /* Malibu.swift */,
@@ -400,6 +414,24 @@
 				D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		DAA50FF61C9A1D8800D01F78 /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */,
+				DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */,
+			);
+			path = Tasks;
+			sourceTree = "<group>";
+		};
+		DAA510001C9A2D2000D01F78 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				DAA510011C9A2D3C00D01F78 /* MockRequest.swift */,
+				DAA510041C9A2D5800D01F78 /* MockDataTask.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		DAC92A341C87B8F300F01940 /* Validation */ = {
@@ -683,6 +715,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAA510051C9A2D5800D01F78 /* MockDataTask.swift in Sources */,
+				DAA50FF81C9A1E8800D01F78 /* SessionDataTask.swift in Sources */,
 				DA5B4CEC1C8E51A0004E21ED /* DataSerializer.swift in Sources */,
 				DAC92A3C1C87C00C00F01940 /* ContentTypeValidator.swift in Sources */,
 				D503D3901C8DA95B0009BDAD /* JSONSerializer.swift in Sources */,
@@ -691,6 +725,7 @@
 				DAC92A361C87B92200F01940 /* Validating.swift in Sources */,
 				DAEE2BAE1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
 				D5B965131C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */,
+				DAA50FFB1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */,
 				D5B9651C1C922BDC0099D2F9 /* NetworkResult.swift in Sources */,
 				D503D38D1C8DA7730009BDAD /* Serializing.swift in Sources */,
 				D5B964F51C92125E0099D2F9 /* Requestable.swift in Sources */,
@@ -704,6 +739,7 @@
 				DA5B4D0A1C8E59A2004E21ED /* Networking.swift in Sources */,
 				DAC92A391C87B95100F01940 /* StatusCodeValidator.swift in Sources */,
 				DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */,
+				DAA510021C9A2D3C00D01F78 /* MockRequest.swift in Sources */,
 				D5B964F21C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651E1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* Error.swift in Sources */,
@@ -747,6 +783,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAA510061C9A2D5800D01F78 /* MockDataTask.swift in Sources */,
+				DAA50FF91C9A1E8800D01F78 /* SessionDataTask.swift in Sources */,
 				DA5B4CED1C8E51A0004E21ED /* DataSerializer.swift in Sources */,
 				DAC92A3D1C87C00C00F01940 /* ContentTypeValidator.swift in Sources */,
 				D503D3911C8DA95B0009BDAD /* JSONSerializer.swift in Sources */,
@@ -755,6 +793,7 @@
 				DAC92A371C87B92200F01940 /* Validating.swift in Sources */,
 				DAEE2BAF1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
 				D5B965141C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */,
+				DAA50FFC1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */,
 				D5B9651D1C922BDC0099D2F9 /* NetworkResult.swift in Sources */,
 				D503D38E1C8DA7730009BDAD /* Serializing.swift in Sources */,
 				D5B964F61C92125E0099D2F9 /* Requestable.swift in Sources */,
@@ -768,6 +807,7 @@
 				DA5B4D0B1C8E59A2004E21ED /* Networking.swift in Sources */,
 				DAC92A3A1C87B95100F01940 /* StatusCodeValidator.swift in Sources */,
 				DA5B4CF01C8E5553004E21ED /* StringSerializer.swift in Sources */,
+				DAA510031C9A2D3C00D01F78 /* MockRequest.swift in Sources */,
 				D5B964F31C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651F1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* Error.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
 		D527ED901C9B73D80092AD6B /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8F1C9B73D80092AD6B /* MockSpec.swift */; };
 		D527ED911C9B73D80092AD6B /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8F1C9B73D80092AD6B /* MockSpec.swift */; };
+		D527ED931C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */; };
+		D527ED941C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8571C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8591C8F6BB500588A0C /* DataSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */; };
@@ -155,6 +157,7 @@
 		D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunningSpec.swift; sourceTree = "<group>"; };
 		D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskSpec.swift; sourceTree = "<group>"; };
 		D527ED8F1C9B73D80092AD6B /* MockSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSpec.swift; sourceTree = "<group>"; };
+		D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataTaskSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C85B1C8F6C8800588A0C /* StringSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializerSpec.swift; sourceTree = "<group>"; };
@@ -290,6 +293,7 @@
 			isa = PBXGroup;
 			children = (
 				D527ED8F1C9B73D80092AD6B /* MockSpec.swift */,
+				D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -803,6 +807,7 @@
 				D560A2E71C8C694100D4B640 /* ContentTypeValidatorSpec.swift in Sources */,
 				D560A2E41C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */,
 				D5B965351C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
+				D527ED931C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */,
 				D5B9652E1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
 				D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
 				D549C85C1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
@@ -874,6 +879,7 @@
 				D560A2E81C8C694100D4B640 /* ContentTypeValidatorSpec.swift in Sources */,
 				D560A2E51C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */,
 				D5B965361C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
+				D527ED941C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */,
 				D5B9652F1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
 				D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
 				D549C85D1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		D503D3911C8DA95B0009BDAD /* JSONSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */; };
 		D503D3A51C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
 		D503D3A61C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
+		D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
+		D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8571C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8591C8F6BB500588A0C /* DataSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */; };
@@ -24,8 +26,8 @@
 		D560A2E71C8C694100D4B640 /* ContentTypeValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D560A2E61C8C694100D4B640 /* ContentTypeValidatorSpec.swift */; };
 		D560A2E81C8C694100D4B640 /* ContentTypeValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D560A2E61C8C694100D4B640 /* ContentTypeValidatorSpec.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Malibu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Malibu.framework */; };
-		D5B964EE1C916CBF0099D2F9 /* TestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964ED1C916CBF0099D2F9 /* TestRequest.swift */; };
-		D5B964EF1C916CBF0099D2F9 /* TestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964ED1C916CBF0099D2F9 /* TestRequest.swift */; };
+		D5B964EE1C916CBF0099D2F9 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964ED1C916CBF0099D2F9 /* Mocks.swift */; };
+		D5B964EF1C916CBF0099D2F9 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964ED1C916CBF0099D2F9 /* Mocks.swift */; };
 		D5B964F21C9211AF0099D2F9 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964F11C9211AF0099D2F9 /* Message.swift */; };
 		D5B964F31C9211AF0099D2F9 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964F11C9211AF0099D2F9 /* Message.swift */; };
 		D5B964F51C92125E0099D2F9 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964F41C92125E0099D2F9 /* Requestable.swift */; };
@@ -146,6 +148,7 @@
 		D503D38C1C8DA7730009BDAD /* Serializing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializing.swift; sourceTree = "<group>"; };
 		D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
+		D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunningSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C85B1C8F6C8800588A0C /* StringSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializerSpec.swift; sourceTree = "<group>"; };
@@ -153,7 +156,7 @@
 		D560A2E61C8C694100D4B640 /* ContentTypeValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentTypeValidatorSpec.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Malibu.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Malibu.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Malibu-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Malibu-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5B964ED1C916CBF0099D2F9 /* TestRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestRequest.swift; sourceTree = "<group>"; };
+		D5B964ED1C916CBF0099D2F9 /* Mocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		D5B964F11C9211AF0099D2F9 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		D5B964F41C92125E0099D2F9 /* Requestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		D5B964F81C9216FD0099D2F9 /* MessageSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSpec.swift; sourceTree = "<group>"; };
@@ -263,9 +266,17 @@
 			isa = PBXGroup;
 			children = (
 				D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */,
-				D5B964ED1C916CBF0099D2F9 /* TestRequest.swift */,
+				D5B964ED1C916CBF0099D2F9 /* Mocks.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		D527ED871C9B6AAD0092AD6B /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */,
+			);
+			path = Tasks;
 			sourceTree = "<group>";
 		};
 		D549C8541C8F65FE00588A0C /* Serialization */ = {
@@ -461,6 +472,7 @@
 				DAEE2BB31C7F8C500000FB12 /* Encoding */,
 				D560A2E21C8C663000D4B640 /* Validation */,
 				D549C8541C8F65FE00588A0C /* Serialization */,
+				D527ED871C9B6AAD0092AD6B /* Tasks */,
 				D5B964F71C9216EB0099D2F9 /* Request */,
 				D5B965221C922BF90099D2F9 /* Response */,
 				DAC92A101C7FCF9000F01940 /* MalibuSpec.swift */,
@@ -764,7 +776,7 @@
 				DAEE2BB71C7F8C5D0000FB12 /* JSONParameterEncoderSpec.swift in Sources */,
 				DAC92A131C7FCF9400F01940 /* MalibuSpec.swift in Sources */,
 				D5B9652C1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */,
-				D5B964EE1C916CBF0099D2F9 /* TestRequest.swift in Sources */,
+				D5B964EE1C916CBF0099D2F9 /* Mocks.swift in Sources */,
 				DA5B4D131C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
 				D5B964FC1C9217140099D2F9 /* RequestableSpec.swift in Sources */,
 				DAA50FF41C9786BE00D01F78 /* HeaderSpec.swift in Sources */,
@@ -774,6 +786,7 @@
 				D560A2E41C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */,
 				D5B965351C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
 				D5B9652E1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
+				D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
 				D549C85C1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D5B965301C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
 			);
@@ -832,7 +845,7 @@
 				DAEE2BB81C7F8C5E0000FB12 /* JSONParameterEncoderSpec.swift in Sources */,
 				DAC92A141C7FCF9500F01940 /* MalibuSpec.swift in Sources */,
 				D5B9652D1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */,
-				D5B964EF1C916CBF0099D2F9 /* TestRequest.swift in Sources */,
+				D5B964EF1C916CBF0099D2F9 /* Mocks.swift in Sources */,
 				DA5B4D141C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
 				D5B964FD1C9217140099D2F9 /* RequestableSpec.swift in Sources */,
 				DAA50FF51C9786BE00D01F78 /* HeaderSpec.swift in Sources */,
@@ -842,6 +855,7 @@
 				D560A2E51C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */,
 				D5B965361C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
 				D5B9652F1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
+				D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
 				D549C85D1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D5B965311C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
 			);

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
 		D527ED8C1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
 		D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
+		D527ED901C9B73D80092AD6B /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8F1C9B73D80092AD6B /* MockSpec.swift */; };
+		D527ED911C9B73D80092AD6B /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8F1C9B73D80092AD6B /* MockSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8571C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8591C8F6BB500588A0C /* DataSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */; };
@@ -99,8 +101,8 @@
 		DAA50FF91C9A1E8800D01F78 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */; };
 		DAA50FFB1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */; };
 		DAA50FFC1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */; };
-		DAA510021C9A2D3C00D01F78 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* MockRequest.swift */; };
-		DAA510031C9A2D3C00D01F78 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* MockRequest.swift */; };
+		DAA510021C9A2D3C00D01F78 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* Mock.swift */; };
+		DAA510031C9A2D3C00D01F78 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* Mock.swift */; };
 		DAA510051C9A2D5800D01F78 /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510041C9A2D5800D01F78 /* MockDataTask.swift */; };
 		DAA510061C9A2D5800D01F78 /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510041C9A2D5800D01F78 /* MockDataTask.swift */; };
 		DAC92A061C7F90B400F01940 /* Malibu.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC92A051C7F90B400F01940 /* Malibu.swift */; };
@@ -152,6 +154,7 @@
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
 		D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunningSpec.swift; sourceTree = "<group>"; };
 		D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskSpec.swift; sourceTree = "<group>"; };
+		D527ED8F1C9B73D80092AD6B /* MockSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C85B1C8F6C8800588A0C /* StringSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializerSpec.swift; sourceTree = "<group>"; };
@@ -201,7 +204,7 @@
 		DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderSpec.swift; sourceTree = "<group>"; };
 		DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTask.swift; sourceTree = "<group>"; };
 		DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunning.swift; sourceTree = "<group>"; };
-		DAA510011C9A2D3C00D01F78 /* MockRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequest.swift; sourceTree = "<group>"; };
+		DAA510011C9A2D3C00D01F78 /* Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		DAA510041C9A2D5800D01F78 /* MockDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataTask.swift; sourceTree = "<group>"; };
 		DAC92A051C7F90B400F01940 /* Malibu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Malibu.swift; sourceTree = "<group>"; };
 		DAC92A081C7F961900F01940 /* FormURLEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormURLEncoder.swift; sourceTree = "<group>"; };
@@ -281,6 +284,14 @@
 				D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */,
 			);
 			path = Tasks;
+			sourceTree = "<group>";
+		};
+		D527ED8E1C9B73C90092AD6B /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				D527ED8F1C9B73D80092AD6B /* MockSpec.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		D549C8541C8F65FE00588A0C /* Serialization */ = {
@@ -443,7 +454,7 @@
 		DAA510001C9A2D2000D01F78 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				DAA510011C9A2D3C00D01F78 /* MockRequest.swift */,
+				DAA510011C9A2D3C00D01F78 /* Mock.swift */,
 				DAA510041C9A2D5800D01F78 /* MockDataTask.swift */,
 			);
 			path = Mocks;
@@ -477,6 +488,7 @@
 				D560A2E21C8C663000D4B640 /* Validation */,
 				D549C8541C8F65FE00588A0C /* Serialization */,
 				D527ED871C9B6AAD0092AD6B /* Tasks */,
+				D527ED8E1C9B73C90092AD6B /* Mocks */,
 				D5B964F71C9216EB0099D2F9 /* Request */,
 				D5B965221C922BF90099D2F9 /* Response */,
 				DAC92A101C7FCF9000F01940 /* MalibuSpec.swift */,
@@ -755,7 +767,7 @@
 				DA5B4D0A1C8E59A2004E21ED /* Networking.swift in Sources */,
 				DAC92A391C87B95100F01940 /* StatusCodeValidator.swift in Sources */,
 				DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */,
-				DAA510021C9A2D3C00D01F78 /* MockRequest.swift in Sources */,
+				DAA510021C9A2D3C00D01F78 /* Mock.swift in Sources */,
 				D5B964F21C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651E1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* Error.swift in Sources */,
@@ -784,6 +796,7 @@
 				DA5B4D131C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
 				D527ED8C1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */,
 				D5B964FC1C9217140099D2F9 /* RequestableSpec.swift in Sources */,
+				D527ED901C9B73D80092AD6B /* MockSpec.swift in Sources */,
 				DAA50FF41C9786BE00D01F78 /* HeaderSpec.swift in Sources */,
 				DAC92A0E1C7FA5F500F01940 /* FormURLEncoderSpec.swift in Sources */,
 				D5B965241C922C1F0099D2F9 /* ETagStorageSpec.swift in Sources */,
@@ -825,7 +838,7 @@
 				DA5B4D0B1C8E59A2004E21ED /* Networking.swift in Sources */,
 				DAC92A3A1C87B95100F01940 /* StatusCodeValidator.swift in Sources */,
 				DA5B4CF01C8E5553004E21ED /* StringSerializer.swift in Sources */,
-				DAA510031C9A2D3C00D01F78 /* MockRequest.swift in Sources */,
+				DAA510031C9A2D3C00D01F78 /* Mock.swift in Sources */,
 				D5B964F31C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651F1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* Error.swift in Sources */,
@@ -854,6 +867,7 @@
 				DA5B4D141C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
 				D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */,
 				D5B964FD1C9217140099D2F9 /* RequestableSpec.swift in Sources */,
+				D527ED911C9B73D80092AD6B /* MockSpec.swift in Sources */,
 				DAA50FF51C9786BE00D01F78 /* HeaderSpec.swift in Sources */,
 				DAC92A0F1C7FA5F600F01940 /* FormURLEncoderSpec.swift in Sources */,
 				D5B965251C922C1F0099D2F9 /* ETagStorageSpec.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		D503D3A61C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
 		D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
 		D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
+		D527ED8C1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
+		D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8571C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8591C8F6BB500588A0C /* DataSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */; };
@@ -149,6 +151,7 @@
 		D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
 		D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunningSpec.swift; sourceTree = "<group>"; };
+		D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C85B1C8F6C8800588A0C /* StringSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializerSpec.swift; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 			isa = PBXGroup;
 			children = (
 				D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */,
+				D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */,
 			);
 			path = Tasks;
 			sourceTree = "<group>";
@@ -778,6 +782,7 @@
 				D5B9652C1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */,
 				D5B964EE1C916CBF0099D2F9 /* Mocks.swift in Sources */,
 				DA5B4D131C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
+				D527ED8C1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */,
 				D5B964FC1C9217140099D2F9 /* RequestableSpec.swift in Sources */,
 				DAA50FF41C9786BE00D01F78 /* HeaderSpec.swift in Sources */,
 				DAC92A0E1C7FA5F500F01940 /* FormURLEncoderSpec.swift in Sources */,
@@ -847,6 +852,7 @@
 				D5B9652D1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */,
 				D5B964EF1C916CBF0099D2F9 /* Mocks.swift in Sources */,
 				DA5B4D141C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
+				D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */,
 				D5B964FD1C9217140099D2F9 /* RequestableSpec.swift in Sources */,
 				DAA50FF51C9786BE00D01F78 /* HeaderSpec.swift in Sources */,
 				DAC92A0F1C7FA5F600F01940 /* FormURLEncoderSpec.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		D527ED911C9B73D80092AD6B /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8F1C9B73D80092AD6B /* MockSpec.swift */; };
 		D527ED931C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */; };
 		D527ED941C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */; };
+		D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
+		D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8571C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
 		D549C8591C8F6BB500588A0C /* DataSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */; };
@@ -158,6 +160,7 @@
 		D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskSpec.swift; sourceTree = "<group>"; };
 		D527ED8F1C9B73D80092AD6B /* MockSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSpec.swift; sourceTree = "<group>"; };
 		D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataTaskSpec.swift; sourceTree = "<group>"; };
+		D527ED981C9B84A20092AD6B /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C85B1C8F6C8800588A0C /* StringSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializerSpec.swift; sourceTree = "<group>"; };
@@ -364,6 +367,7 @@
 				D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */,
 				D5B964F81C9216FD0099D2F9 /* MessageSpec.swift */,
 				D5B964FB1C9217140099D2F9 /* RequestableSpec.swift */,
+				D527ED981C9B84A20092AD6B /* MethodSpec.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -811,6 +815,7 @@
 				D5B9652E1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
 				D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
 				D549C85C1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
+				D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */,
 				D5B965301C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -883,6 +888,7 @@
 				D5B9652F1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
 				D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
 				D549C85D1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
+				D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */,
 				D5B965311C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MalibuTests/Helpers/Mocks.swift
+++ b/MalibuTests/Helpers/Mocks.swift
@@ -1,0 +1,28 @@
+import Foundation
+import When
+@testable import Malibu
+
+struct TestRequest: Requestable {
+  var message = Message(resource: "http://hyper.no")
+}
+
+class TestNetworkTask: NetworkTaskRunning {
+  let URLRequest: NSURLRequest
+  let promise: Promise<NetworkResult>
+  let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
+  let response: NSHTTPURLResponse
+
+  // MARK: - Initialization
+
+  init() {
+    URLRequest = try! TestRequest().toURLRequest(.GET)
+    promise = Promise<NetworkResult>()
+    response = NSHTTPURLResponse(URL: URLRequest.URL!, statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
+  }
+
+  // MARK: - NetworkTaskRunning
+
+  func run() {
+    process(data, response: response, error: nil)
+  }
+}

--- a/MalibuTests/Helpers/TestRequest.swift
+++ b/MalibuTests/Helpers/TestRequest.swift
@@ -1,6 +1,0 @@
-import Foundation
-import Malibu
-
-struct TestRequest: Requestable {
-  var message = Message(resource: "http://hyper.no")
-}

--- a/MalibuTests/Specs/MalibuSpec.swift
+++ b/MalibuTests/Specs/MalibuSpec.swift
@@ -8,24 +8,24 @@ class MalibuSpec: QuickSpec {
     describe("Malibu") {
       let baseURLString = "http://hyper.no"
       let surferNetworking = Networking(baseURLString: baseURLString)
-      
+
       beforeEach {
         Malibu.networkings.removeAll()
         Malibu.register("surfer", networking: surferNetworking)
       }
-      
+
       describe(".methodsWithEtags") {
         it("has GET, PATCH, PUT methods") {
           expect(Malibu.methodsWithEtags).to(equal([.GET, .PATCH, .PUT]))
         }
       }
-      
+
       describe(".mode") {
         it("is regular by default") {
           expect(Malibu.mode).to(equal(Malibu.Mode.Regular))
         }
       }
-      
+
       describe(".parameterEncoders") {
         it("has default encoders for content types") {
           expect(Malibu.parameterEncoders.isEmpty).to(beFalse())
@@ -33,7 +33,7 @@ class MalibuSpec: QuickSpec {
           expect(Malibu.parameterEncoders[.FormURLEncoded] is FormURLEncoder).to(beTrue())
         }
       }
-      
+
       describe(".register:networking") {
         it("adds new networking instance with a name") {
           expect(Malibu.networkings.count).to(equal(1))
@@ -46,23 +46,34 @@ class MalibuSpec: QuickSpec {
           expect(Malibu.networkings.count).to(equal(1))
 
           Malibu.unregister("surfer")
-          
+
           expect(Malibu.networkings.count).to(equal(0))
         }
       }
-      
-      describe("networkingNamed") {
+
+      describe(".networkingNamed") {
         context("when there is a networking registered with this name") {
           it("returns registered networking") {
             expect(networkingNamed("surfer") === surferNetworking).to(beTrue())
           }
         }
-        
+
         context("when there is no networking registered with this name") {
           it("returns default networking") {
             Malibu.unregister("surfer")
             expect(networkingNamed("surfer") === Malibu.backfootSurfer).to(beTrue())
           }
+        }
+      }
+
+      describe(".registerMock:on") {
+        it("registers mock for the provided method on default networking") {
+          let request = TestRequest()
+          let mock = Mock(request: request, response: nil, data: nil, error: nil)
+
+          Malibu.registerMock(mock, on: .GET)
+
+          expect(Malibu.backfootSurfer.mocks["GET http://hyper.no"] === mock).to(beTrue())
         }
       }
     }

--- a/MalibuTests/Specs/MalibuSpec.swift
+++ b/MalibuTests/Specs/MalibuSpec.swift
@@ -20,6 +20,12 @@ class MalibuSpec: QuickSpec {
         }
       }
       
+      describe(".mode") {
+        it("is regular by default") {
+          expect(Malibu.mode).to(equal(Malibu.Mode.Regular))
+        }
+      }
+      
       describe(".parameterEncoders") {
         it("has default encoders for content types") {
           expect(Malibu.parameterEncoders.isEmpty).to(beFalse())

--- a/MalibuTests/Specs/MalibuSpec.swift
+++ b/MalibuTests/Specs/MalibuSpec.swift
@@ -6,11 +6,57 @@ class MalibuSpec: QuickSpec {
 
   override func spec() {
     describe("Malibu") {
+      let baseURLString = "http://hyper.no"
+      let surferNetworking = Networking(baseURLString: baseURLString)
+      
+      beforeEach {
+        Malibu.networkings.removeAll()
+        Malibu.register("surfer", networking: surferNetworking)
+      }
+      
+      describe(".methodsWithEtags") {
+        it("has GET, PATCH, PUT methods") {
+          expect(Malibu.methodsWithEtags).to(equal([.GET, .PATCH, .PUT]))
+        }
+      }
+      
       describe(".parameterEncoders") {
         it("has default encoders for content types") {
           expect(Malibu.parameterEncoders.isEmpty).to(beFalse())
           expect(Malibu.parameterEncoders[.JSON] is JSONParameterEncoder).to(beTrue())
           expect(Malibu.parameterEncoders[.FormURLEncoded] is FormURLEncoder).to(beTrue())
+        }
+      }
+      
+      describe(".register:networking") {
+        it("adds new networking instance with a name") {
+          expect(Malibu.networkings.count).to(equal(1))
+          expect(Malibu.networkings["surfer"]?.baseURLString?.URLString).to(equal(baseURLString.URLString))
+        }
+      }
+
+      describe(".unregister") {
+        it("removed a networking instance by name") {
+          expect(Malibu.networkings.count).to(equal(1))
+
+          Malibu.unregister("surfer")
+          
+          expect(Malibu.networkings.count).to(equal(0))
+        }
+      }
+      
+      describe("networkingNamed") {
+        context("when there is a networking registered with this name") {
+          it("returns registered networking") {
+            expect(networkingNamed("surfer") === surferNetworking).to(beTrue())
+          }
+        }
+        
+        context("when there is no networking registered with this name") {
+          it("returns default networking") {
+            Malibu.unregister("surfer")
+            expect(networkingNamed("surfer") === Malibu.backfootSurfer).to(beTrue())
+          }
         }
       }
     }

--- a/MalibuTests/Specs/Mocks/MockDataTaskSpec.swift
+++ b/MalibuTests/Specs/Mocks/MockDataTaskSpec.swift
@@ -24,7 +24,7 @@ class MockDataSpec: QuickSpec {
         promise = Promise<NetworkResult>()
       }
 
-      describe("init") {
+      describe("#init") {
         beforeEach {
           mock = Mock(request: request, response: response, data: data, error: error)
           task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
@@ -37,7 +37,7 @@ class MockDataSpec: QuickSpec {
         }
       }
 
-      describe("run") {
+      describe("#run") {
         context("when response is nil") {
           it("rejects promise with an error") {
             let expectation = self.expectationWithDescription("No response failure")

--- a/MalibuTests/Specs/Mocks/MockDataTaskSpec.swift
+++ b/MalibuTests/Specs/Mocks/MockDataTaskSpec.swift
@@ -1,0 +1,118 @@
+@testable import Malibu
+import Quick
+import Nimble
+import When
+
+class MockDataSpec: QuickSpec {
+
+  override func spec() {
+    describe("MockDataTask") {
+      var task: MockDataTask!
+      var mock: Mock!
+      var request: Requestable!
+      var URLRequest: NSURLRequest!
+      var response: NSHTTPURLResponse!
+      var promise: Promise<NetworkResult>!
+      let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
+      let error = Error.JSONArraySerializationFailed
+
+      beforeEach {
+        request = TestRequest()
+        URLRequest = try! request.toURLRequest(.GET)
+        response = NSHTTPURLResponse(URL: NSURL(string: "http://hyper.no")!,
+          statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
+        promise = Promise<NetworkResult>()
+      }
+
+      describe("init") {
+        beforeEach {
+          mock = Mock(request: request, response: response, data: data, error: error)
+          task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
+        }
+
+        it("sets properties") {
+          expect(task.mock === mock).to(beTrue())
+          expect(task.URLRequest).to(equal(URLRequest))
+          expect(task.promise === promise).to(beTrue())
+        }
+      }
+
+      describe("run") {
+        context("when response is nil") {
+          it("rejects promise with an error") {
+            let expectation = self.expectationWithDescription("No response failure")
+
+            mock = Mock(request: request, response: nil, data: data, error: nil)
+            task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
+
+            task.promise.fail({ error in
+              expect(error as! Error == Error.NoResponseReceived).to(beTrue())
+              expectation.fulfill()
+            })
+
+            task.run()
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+
+        context("when there is an error") {
+          it("rejects promise with an error") {
+            let expectation = self.expectationWithDescription("Error failure")
+
+            mock = Mock(request: request, response: response, data: data, error: error)
+            task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
+
+            task.promise.fail({ error in
+              expect(error as! Error == Error.JSONArraySerializationFailed).to(beTrue())
+              expectation.fulfill()
+            })
+
+            task.run()
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+
+        context("when there is no data") {
+          it("rejects promise with an error") {
+            let expectation = self.expectationWithDescription("No data failure")
+
+            mock = Mock(request: request, response: response, data: nil, error: nil)
+            task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
+
+            task.promise.fail({ error in
+              expect(error as! Error == Error.NoDataInResponse).to(beTrue())
+              expectation.fulfill()
+            })
+
+            task.run()
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+
+        context("when validation succeeded") {
+          it("resolves promise with a result") {
+            let expectation = self.expectationWithDescription("Validation succeeded")
+
+            mock = Mock(request: request, response: response, data: data, error: nil)
+            task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
+
+            task.promise.done({ result in
+              expect(result.data).to(equal(task.mock.data))
+              expect(result.request).to(equal(task.URLRequest))
+              expect(result.response).to(equal(task.mock.response))
+
+              expectation.fulfill()
+            })
+
+            task.run()
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+      }
+    }
+  }
+}

--- a/MalibuTests/Specs/Mocks/MockSpec.swift
+++ b/MalibuTests/Specs/Mocks/MockSpec.swift
@@ -14,7 +14,7 @@ class MockSpec: QuickSpec {
       let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
       let error = Error.NoDataInResponse
 
-      describe("init") {
+      describe("#init") {
         beforeEach {
           mock = Mock(request: request, response: response, data: data, error: error)
         }

--- a/MalibuTests/Specs/Mocks/MockSpec.swift
+++ b/MalibuTests/Specs/Mocks/MockSpec.swift
@@ -1,0 +1,31 @@
+@testable import Malibu
+import Quick
+import Nimble
+import When
+
+class MockSpec: QuickSpec {
+
+  override func spec() {
+    describe("SessionDataTask") {
+      var mock: Mock!
+      let request = TestRequest()
+      let response = NSHTTPURLResponse(URL: NSURL(string: "http://hyper.no")!,
+        statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
+      let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
+      let error = Error.NoDataInResponse
+
+      describe("init") {
+        beforeEach {
+          mock = Mock(request: request, response: response, data: data, error: error)
+        }
+
+        it("sets properties") {
+          expect(mock.request.message).to(equal(request.message))
+          expect(mock.response).to(equal(response))
+          expect(mock.data).to(equal(data))
+          expect(mock.error as! Error == error).to(beTrue())
+        }
+      }
+    }
+  }
+}

--- a/MalibuTests/Specs/Mocks/MockSpec.swift
+++ b/MalibuTests/Specs/Mocks/MockSpec.swift
@@ -6,7 +6,7 @@ import When
 class MockSpec: QuickSpec {
 
   override func spec() {
-    describe("SessionDataTask") {
+    describe("Mock") {
       var mock: Mock!
       let request = TestRequest()
       let response = NSHTTPURLResponse(URL: NSURL(string: "http://hyper.no")!,

--- a/MalibuTests/Specs/NetworkingSpec.swift
+++ b/MalibuTests/Specs/NetworkingSpec.swift
@@ -6,9 +6,13 @@ class NetworkingSpec: QuickSpec {
 
   override func spec() {
     describe("Networking") {
-      var networking = Networking()
+      var networking: Networking!
 
-      describe("init") {
+      beforeEach {
+        networking = Networking()
+      }
+
+      describe("#init") {
         it("sets default configuration to the session") {
           networking = Networking()
 
@@ -19,6 +23,17 @@ class NetworkingSpec: QuickSpec {
           networking = Networking(sessionConfiguration: .Background)
 
           expect(networking.session.configuration.identifier).to(equal("MalibuBackgroundConfiguration"))
+        }
+      }
+
+      describe("#registerMock:on") {
+        it("registers mock for the provided method") {
+          let request = TestRequest()
+          let mock = Mock(request: request, response: nil, data: nil, error: nil)
+
+          networking.registerMock(mock, on: .GET)
+
+          expect(networking.mocks["GET http://hyper.no"] === mock).to(beTrue())
         }
       }
     }

--- a/MalibuTests/Specs/Request/MethodSpec.swift
+++ b/MalibuTests/Specs/Request/MethodSpec.swift
@@ -13,7 +13,7 @@ class MethodSpec: QuickSpec {
         request = TestRequest()
       }
 
-      describe("keyFor") {
+      describe("#keyFor") {
         it("bulds a key based on raw value and request URL") {
           expect(Method.GET.keyFor(request)).to(equal("GET http://hyper.no"))
           expect(Method.POST.keyFor(request)).to(equal("POST http://hyper.no"))

--- a/MalibuTests/Specs/Request/MethodSpec.swift
+++ b/MalibuTests/Specs/Request/MethodSpec.swift
@@ -1,0 +1,31 @@
+@testable import Malibu
+import Quick
+import Nimble
+import When
+
+class MethodSpec: QuickSpec {
+
+  override func spec() {
+    describe("Method") {
+      var request: Requestable!
+
+      beforeEach {
+        request = TestRequest()
+      }
+
+      describe("keyFor") {
+        it("bulds a key based on raw value and request URL") {
+          expect(Method.GET.keyFor(request)).to(equal("GET http://hyper.no"))
+          expect(Method.POST.keyFor(request)).to(equal("POST http://hyper.no"))
+          expect(Method.PUT.keyFor(request)).to(equal("PUT http://hyper.no"))
+          expect(Method.PATCH.keyFor(request)).to(equal("PATCH http://hyper.no"))
+          expect(Method.DELETE.keyFor(request)).to(equal("DELETE http://hyper.no"))
+          expect(Method.HEAD.keyFor(request)).to(equal("HEAD http://hyper.no"))
+          expect(Method.OPTIONS.keyFor(request)).to(equal("OPTIONS http://hyper.no"))
+          expect(Method.TRACE.keyFor(request)).to(equal("TRACE http://hyper.no"))
+          expect(Method.CONNECT.keyFor(request)).to(equal("CONNECT http://hyper.no"))
+        }
+      }
+    }
+  }
+}

--- a/MalibuTests/Specs/Tasks/NetworkTaskRunningSpec.swift
+++ b/MalibuTests/Specs/Tasks/NetworkTaskRunningSpec.swift
@@ -60,7 +60,7 @@ class NetworkTaskRunningSpec: QuickSpec {
         }
 
         context("when validation succeeded") {
-          it("rresolves promise with a result") {
+          it("resolves promise with a result") {
             let expectation = self.expectationWithDescription("Validation succeeded")
 
             task.promise.done({ result in

--- a/MalibuTests/Specs/Tasks/NetworkTaskRunningSpec.swift
+++ b/MalibuTests/Specs/Tasks/NetworkTaskRunningSpec.swift
@@ -1,0 +1,82 @@
+@testable import Malibu
+import Quick
+import Nimble
+import When
+
+class NetworkTaskRunningSpec: QuickSpec {
+
+  override func spec() {
+    describe("NetworkTaskRunning") {
+      var task: TestNetworkTask!
+
+      beforeEach {
+        task = TestNetworkTask()
+      }
+
+      describe("process") {
+        context("when response is nil") {
+          it("rejects promise with an error") {
+            let expectation = self.expectationWithDescription("No response failure")
+
+            task.promise.fail({ error in
+              expect(error as! Error == Error.NoResponseReceived).to(beTrue())
+              expectation.fulfill()
+            })
+
+            task.process(task.data, response: nil, error: nil)
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+
+        context("when there is an error") {
+          it("rejects promise with an error") {
+            let expectation = self.expectationWithDescription("Error failure")
+
+            task.promise.fail({ error in
+              expect(error as! Error == Error.JSONDictionarySerializationFailed).to(beTrue())
+              expectation.fulfill()
+            })
+
+            task.process(task.data, response: task.response, error: Error.JSONDictionarySerializationFailed)
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+
+        context("when there is no data") {
+          it("rejects promise with an error") {
+            let expectation = self.expectationWithDescription("No data failure")
+
+            task.promise.fail({ error in
+              expect(error as! Error == Error.NoDataInResponse).to(beTrue())
+              expectation.fulfill()
+            })
+
+            task.process(nil, response: task.response, error: nil)
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+
+        context("when validation succeeded") {
+          it("rresolves promise with a result") {
+            let expectation = self.expectationWithDescription("Validation succeeded")
+
+            task.promise.done({ result in
+              expect(result.data).to(equal(task.data))
+              expect(result.request).to(equal(task.URLRequest))
+              expect(result.response).to(equal(task.response))
+
+              expectation.fulfill()
+            })
+
+            task.process(task.data, response: task.response, error: nil)
+
+            self.waitForExpectationsWithTimeout(4.0, handler:nil)
+          }
+        }
+      }
+    }
+  }
+}

--- a/MalibuTests/Specs/Tasks/NetworkTaskRunningSpec.swift
+++ b/MalibuTests/Specs/Tasks/NetworkTaskRunningSpec.swift
@@ -13,7 +13,7 @@ class NetworkTaskRunningSpec: QuickSpec {
         task = TestNetworkTask()
       }
 
-      describe("process") {
+      describe("#process") {
         context("when response is nil") {
           it("rejects promise with an error") {
             let expectation = self.expectationWithDescription("No response failure")

--- a/MalibuTests/Specs/Tasks/SessionDataTaskSpec.swift
+++ b/MalibuTests/Specs/Tasks/SessionDataTaskSpec.swift
@@ -12,7 +12,7 @@ class SessionDataTaskSpec: QuickSpec {
       let URLRequest = try! TestRequest().toURLRequest(.GET)
       let promise = Promise<NetworkResult>()
 
-      describe("init") {
+      describe("#init") {
         beforeEach {
           task = SessionDataTask(session: session, URLRequest: URLRequest, promise: promise)
         }

--- a/MalibuTests/Specs/Tasks/SessionDataTaskSpec.swift
+++ b/MalibuTests/Specs/Tasks/SessionDataTaskSpec.swift
@@ -1,0 +1,28 @@
+@testable import Malibu
+import Quick
+import Nimble
+import When
+
+class SessionDataTaskSpec: QuickSpec {
+
+  override func spec() {
+    describe("SessionDataTask") {
+      var task: SessionDataTask!
+      let session = NSURLSession()
+      let URLRequest = try! TestRequest().toURLRequest(.GET)
+      let promise = Promise<NetworkResult>()
+
+      describe("init") {
+        beforeEach {
+          task = SessionDataTask(session: session, URLRequest: URLRequest, promise: promise)
+        }
+
+        it("sets properties") {
+          expect(task.session).to(equal(session))
+          expect(task.URLRequest).to(equal(URLRequest))
+          expect(task.promise === promise).to(beTrue())
+        }
+      }
+    }
+  }
+}

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum Error: ErrorType {
+  case NoMockProvided
   case InvalidRequestURL
   case MissingContentType
   case NoDataInResponse
@@ -15,6 +16,8 @@ public enum Error: ErrorType {
     var text: String
 
     switch self {
+    case .NoMockProvided:
+      text = "No mock provided for the current request and method"
     case .InvalidRequestURL:
       text = "Invalid request URL"
     case .MissingContentType:

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -34,6 +34,12 @@ public func networkingNamed(name: String) -> Networking {
   return networkings[name] ?? backfootSurfer
 }
 
+// MARK: - Mocks
+
+public func registerMock(mock: Mock, on method: Method) {
+  backfootSurfer.registerMock(mock, on: method)
+}
+
 // MARK: - Requests
 
 public func GET(request: Requestable) -> Promise<NetworkResult> {

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -19,6 +19,10 @@ public func register(name: String, networking: Networking) {
   networkings[name] = networking
 }
 
+public func remove(name: String) -> Bool {
+  return networkings.removeValueForKey(name) != nil
+}
+
 public func networkingNamed(name: String) -> Networking {
   return networkings[name] ?? backfootSurfer
 }

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -1,8 +1,25 @@
 import Foundation
 
+// MARK: - Helpers
+
+var methodsWithEtags: [Method] = [.GET, .PATCH, .PUT]
+var networkings = [String: Networking]()
+
+// MARK: - Public
+
+public var networking = Networking()
+
 public var parameterEncoders: [ContentType: ParameterEncoding] = [
   .JSON: JSONParameterEncoder(),
   .FormURLEncoded: FormURLEncoder()
 ]
 
-var methodsWithEtags: [Method] = [.GET, .PATCH, .PUT]
+public func register(name: String, networking: Networking) {
+  networkings[name] = networking
+}
+
+public func networkingNamed(name: String) -> Networking {
+  return networkings[name] ?? networking
+}
+
+

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -15,11 +15,13 @@ public var parameterEncoders: [ContentType: ParameterEncoding] = [
   .FormURLEncoded: FormURLEncoder()
 ]
 
+// MARK: - Networkings
+
 public func register(name: String, networking: Networking) {
   networkings[name] = networking
 }
 
-public func remove(name: String) -> Bool {
+public func unregister(name: String) -> Bool {
   return networkings.removeValueForKey(name) != nil
 }
 

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -1,6 +1,10 @@
 import Foundation
 import When
 
+public enum Mode {
+  case Regular, Fake
+}
+
 // MARK: - Helpers
 
 var methodsWithEtags: [Method] = [.GET, .PATCH, .PUT]
@@ -8,6 +12,7 @@ var networkings = [String: Networking]()
 
 // MARK: - Public
 
+public var mode: Mode = .Regular
 public var backfootSurfer = Networking()
 
 public var parameterEncoders: [ContentType: ParameterEncoding] = [

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -1,4 +1,5 @@
 import Foundation
+import When
 
 // MARK: - Helpers
 
@@ -7,7 +8,7 @@ var networkings = [String: Networking]()
 
 // MARK: - Public
 
-public var networking = Networking()
+public var backfootSurfer = Networking()
 
 public var parameterEncoders: [ContentType: ParameterEncoding] = [
   .JSON: JSONParameterEncoder(),
@@ -19,7 +20,31 @@ public func register(name: String, networking: Networking) {
 }
 
 public func networkingNamed(name: String) -> Networking {
-  return networkings[name] ?? networking
+  return networkings[name] ?? backfootSurfer
 }
 
+// MARK: - Requests
 
+public func GET(request: Requestable) -> Promise<NetworkResult> {
+  return backfootSurfer.GET(request)
+}
+
+public func POST(request: Requestable) -> Promise<NetworkResult> {
+  return backfootSurfer.POST(request)
+}
+
+public func PUT(request: Requestable) -> Promise<NetworkResult> {
+  return backfootSurfer.PUT(request)
+}
+
+public func PATCH(request: Requestable) -> Promise<NetworkResult> {
+  return backfootSurfer.PATCH(request)
+}
+
+public func DELETE(request: Requestable) -> Promise<NetworkResult> {
+  return backfootSurfer.DELETE(request)
+}
+
+public func HEAD(request: Requestable) -> Promise<NetworkResult> {
+  return backfootSurfer.HEAD(request)
+}

--- a/Sources/Mocks/Mock.swift
+++ b/Sources/Mocks/Mock.swift
@@ -1,13 +1,14 @@
 import Foundation
 
-public class MockRequest {
+public class Mock {
+
   public var request: Requestable
   public var response: NSHTTPURLResponse?
   public var data: NSData?
   public var error: ErrorType?
-  
+
   // MARK: - Initialization
-  
+
   public init(request: Requestable, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType? = nil) {
     self.request = request
     self.data = data

--- a/Sources/Mocks/MockDataTask.swift
+++ b/Sources/Mocks/MockDataTask.swift
@@ -1,0 +1,23 @@
+import Foundation
+import When
+
+class MockDataTask: NetworkTaskRunning {
+  
+  let mock: MockRequest
+  let URLRequest: NSURLRequest
+  let promise: Promise<NetworkResult>
+  
+  // MARK: - Initialization
+  
+  init(URLRequest: NSURLRequest, promise: Promise<NetworkResult>, mock: MockRequest) {
+    self.URLRequest = URLRequest
+    self.promise = promise
+    self.mock = mock
+  }
+  
+  // MARK: - NetworkTaskRunning
+  
+  func run() {
+    process(mock.data, response: mock.response, error: mock.error)
+  }
+}

--- a/Sources/Mocks/MockDataTask.swift
+++ b/Sources/Mocks/MockDataTask.swift
@@ -2,21 +2,21 @@ import Foundation
 import When
 
 class MockDataTask: NetworkTaskRunning {
-  
-  let mock: MockRequest
+
+  let mock: Mock
   let URLRequest: NSURLRequest
   let promise: Promise<NetworkResult>
-  
+
   // MARK: - Initialization
-  
-  init(URLRequest: NSURLRequest, promise: Promise<NetworkResult>, mock: MockRequest) {
+
+  init(mock: Mock, URLRequest: NSURLRequest, promise: Promise<NetworkResult>) {
+    self.mock = mock
     self.URLRequest = URLRequest
     self.promise = promise
-    self.mock = mock
   }
-  
+
   // MARK: - NetworkTaskRunning
-  
+
   func run() {
     process(mock.data, response: mock.response, error: mock.error)
   }

--- a/Sources/Mocks/MockRequest.swift
+++ b/Sources/Mocks/MockRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public class MockRequest {
+  public var request: Requestable
+  public var response: NSHTTPURLResponse?
+  public var data: NSData?
+  public var error: ErrorType?
+  
+  // MARK: - Initialization
+  
+  public init(request: Requestable, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType? = nil) {
+    self.request = request
+    self.data = data
+    self.response = response
+    self.error = error
+  }
+}

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -44,29 +44,29 @@ public class Networking {
     let URLRequest: NSMutableURLRequest
 
     do {
-      URLRequest = try request.toURLRequest(method,
-        baseURLString: baseURLString, additionalHeaders: requestHeaders)
+      URLRequest = try request.toURLRequest(method, baseURLString: baseURLString,
+        additionalHeaders: requestHeaders)
     } catch {
       promise.reject(error)
       return promise
     }
 
     preProcessRequest?(URLRequest)
-    
+
     let task: NetworkTaskRunning
-    
+
     switch Malibu.mode {
     case .Regular:
       task = SessionDataTask(session: session, URLRequest: URLRequest, promise: promise)
     case .Fake:
       task = SessionDataTask(session: session, URLRequest: URLRequest, promise: promise)
     }
-    
+
     task.run()
 
     return promise
   }
-  
+
   // MARK: - Authentication
 
   public func authenticate(username username: String, password: String) {

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -99,8 +99,6 @@ public class Networking {
 
   // MARK: - Helpers
 
-
-
   func saveEtag(key: String, response: NSHTTPURLResponse) {
     guard let etag = response.allHeaderFields["ETag"] as? String else {
       return

--- a/Sources/Request/Method.swift
+++ b/Sources/Request/Method.swift
@@ -8,4 +8,8 @@ public enum Method: String {
   case OPTIONS
   case TRACE
   case CONNECT
+
+  func keyFor(request: Requestable) -> String {
+    return "\(rawValue) \(request.message.resource.URLString)"
+  }
 }

--- a/Sources/Request/URLStringConvertible.swift
+++ b/Sources/Request/URLStringConvertible.swift
@@ -4,12 +4,16 @@ public protocol URLStringConvertible {
   var URLString: String { get }
 }
 
+// MARK: - String
+
 extension String: URLStringConvertible {
 
   public var URLString: String {
     return self
   }
 }
+
+// MARK: - NSURL
 
 extension NSURL: URLStringConvertible {
 

--- a/Sources/Tasks/NetworkTaskRunning.swift
+++ b/Sources/Tasks/NetworkTaskRunning.swift
@@ -1,6 +1,32 @@
 import Foundation
 import When
 
-struct NetworkTaskRunning {
-  func run(URLRequest: NSURLRequest, promise: Promise<NetworkResult>)
+protocol NetworkTaskRunning: class {
+  var URLRequest: NSURLRequest { get }
+  var promise: Promise<NetworkResult> { get }
+  
+  func run()
+}
+
+extension NetworkTaskRunning {
+  
+  func process (data: NSData?, response: NSURLResponse?, error: ErrorType?) -> Void {
+    guard let response = response as? NSHTTPURLResponse else {
+      promise.reject(Error.NoResponseReceived)
+      return
+    }
+    
+    if let error = error {
+      promise.reject(error)
+      return
+    }
+    
+    guard let data = data else {
+      promise.reject(Error.NoDataInResponse)
+      return
+    }
+    
+    let result = NetworkResult(data: data, request: URLRequest, response: response)
+    promise.resolve(result)
+  }
 }

--- a/Sources/Tasks/NetworkTaskRunning.swift
+++ b/Sources/Tasks/NetworkTaskRunning.swift
@@ -4,28 +4,28 @@ import When
 protocol NetworkTaskRunning: class {
   var URLRequest: NSURLRequest { get }
   var promise: Promise<NetworkResult> { get }
-  
+
   func run()
 }
 
 extension NetworkTaskRunning {
-  
-  func process (data: NSData?, response: NSURLResponse?, error: ErrorType?) -> Void {
+
+  func process(data: NSData?, response: NSURLResponse?, error: ErrorType?) {
     guard let response = response as? NSHTTPURLResponse else {
       promise.reject(Error.NoResponseReceived)
       return
     }
-    
+
     if let error = error {
       promise.reject(error)
       return
     }
-    
+
     guard let data = data else {
       promise.reject(Error.NoDataInResponse)
       return
     }
-    
+
     let result = NetworkResult(data: data, request: URLRequest, response: response)
     promise.resolve(result)
   }

--- a/Sources/Tasks/NetworkTaskRunning.swift
+++ b/Sources/Tasks/NetworkTaskRunning.swift
@@ -1,0 +1,6 @@
+import Foundation
+import When
+
+struct NetworkTaskRunning {
+  func run(URLRequest: NSURLRequest, promise: Promise<NetworkResult>)
+}

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -1,9 +1,23 @@
-//
-//  SessionDataTask.swift
-//  Malibu
-//
-//  Created by Vadym Markov on 17/03/16.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+import When
+
+class SessionDataTask: NetworkTaskRunning {
+  
+  var URLRequest: NSURLRequest
+  var promise: Promise<NetworkResult>
+  var session: NSURLSession
+  
+  // MARK: - Initialization
+  
+  init(session: NSURLSession, URLRequest: NSURLRequest, promise: Promise<NetworkResult>) {
+    self.session = session
+    self.URLRequest = URLRequest
+    self.promise = promise
+  }
+  
+  // MARK: - NetworkTaskRunning
+  
+  func run() {
+    session.dataTaskWithRequest(URLRequest, completionHandler: process).resume()
+  }
+}

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -1,0 +1,9 @@
+//
+//  SessionDataTask.swift
+//  Malibu
+//
+//  Created by Vadym Markov on 17/03/16.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -2,21 +2,21 @@ import Foundation
 import When
 
 class SessionDataTask: NetworkTaskRunning {
-  
+
+  var session: NSURLSession
   var URLRequest: NSURLRequest
   var promise: Promise<NetworkResult>
-  var session: NSURLSession
-  
+
   // MARK: - Initialization
-  
+
   init(session: NSURLSession, URLRequest: NSURLRequest, promise: Promise<NetworkResult>) {
     self.session = session
     self.URLRequest = URLRequest
     self.promise = promise
   }
-  
+
   // MARK: - NetworkTaskRunning
-  
+
   func run() {
     session.dataTaskWithRequest(URLRequest, completionHandler: process).resume()
   }


### PR DESCRIPTION
@zenangst @RamonGilabert @onmyway133 

1) Register network with name + default networking instance:
```swift
let networking = Networking(baseURLString: "http://hyper.no/api")
Malibu.register("hyper", networking: networking)

networkingNamed("hyper") // => registered instance
networkingNamed("random") // => backfootSurfer default networking instance 
```

2) Request mocks. You can easily mock your request for testing.
```swift
struct TestRequest: Requestable {
  var message = Message(resource: "http://hyper.no")
}

let request = TestRequest()
let response = NSHTTPURLResponse(URL: NSURL(string: "http://hyper.no")!,
        statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
let mock = Mock(request: request, response: response, data: data, error: nil)

// Register your mock
Malibu.registerMock(mock, on: .GET)

// Enable fake mode
Malibu.mode = .Fake

// Make request
Malibu.GET(request)
   .toString()
   .done({ result in
     print(result) // => "test"   
   })
```