### PR TITLE
Feature Partial mocking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: objective-c
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: objective-c
 
 before_install:
 - brew update
-- brew install carthage
 - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
-- carthage update --platform iOS,Mac
+- if brew outdated | grep -qx carthage; then brew upgrade carthage; fi
+- travis_wait 35 carthage update --platform iOS,Mac
 
 script:
 - xctool clean build -project Malibu.xcodeproj -scheme Malibu-iOS -sdk iphonesimulator

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -2,7 +2,7 @@ import Foundation
 import When
 
 public enum Mode {
-  case Regular, Fake
+  case Regular, Partial, Fake
 }
 
 // MARK: - Helpers

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -66,6 +66,12 @@ public class Networking: NSObject {
     switch Malibu.mode {
     case .Regular:
       task = SessionDataTask(session: session, URLRequest: URLRequest, promise: promise)
+    case .Partial:
+      if let mock = mocks[request.key] {
+        task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
+      } else {
+        task = SessionDataTask(session: session, URLRequest: URLRequest, promise: promise)
+      }
     case .Fake:
       guard let mock = mocks[request.key] else {
         promise.reject(Error.NoMockProvided)


### PR DESCRIPTION
This PR adds a new mode when mocking requests, before we had `.Regular` and `.Fake`.

The new mode `.Partial` looks for mocked requests, if there are any, use them, if they don't exist it tries to do an actual request.

This can be helpful when developing towards an API that is still being built alongside the client.