### PR TITLE
Feature: pre process request

### DIFF
--- a/MalibuTests/Specs/NetworkingSpec.swift
+++ b/MalibuTests/Specs/NetworkingSpec.swift
@@ -36,6 +36,26 @@ class NetworkingSpec: QuickSpec {
           expect(networking.mocks["GET http://hyper.no"] === mock).to(beTrue())
         }
       }
+
+      describe("#prepareMock") {
+        it("runs beforeEach closure on mocked request and returns registered mock") {
+          let request = GETRequest()
+          let mock = Mock(request: request, response: nil, data: nil, error: nil)
+
+          networking.register(mock: mock)
+          networking.beforeEach = { (request: Requestable) in
+            var request = request
+            request.message.parameters["test"] = true
+
+            return request
+          }
+
+          let result = networking.prepareMock(request)
+
+          expect(result).toNot(beNil())
+          expect(result?.request.message.parameters["test"] as? Bool).to(beTrue())
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Closure to modify the each request:
```swift
networking.beforeEach = { request in
  var request = request
  request.message.parameters["test"] = true

  return request
}
```