### PR TITLE
Feature: ride and wave

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -58,22 +58,22 @@
 		D5B965141C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B9650C1C922BCF0099D2F9 /* URLStringConvertible.swift */; };
 		D5B9651A1C922BDC0099D2F9 /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965161C922BDC0099D2F9 /* MIMEType.swift */; };
 		D5B9651B1C922BDC0099D2F9 /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965161C922BDC0099D2F9 /* MIMEType.swift */; };
-		D5B9651C1C922BDC0099D2F9 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965171C922BDC0099D2F9 /* NetworkResult.swift */; };
-		D5B9651D1C922BDC0099D2F9 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965171C922BDC0099D2F9 /* NetworkResult.swift */; };
-		D5B9651E1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965181C922BDC0099D2F9 /* NetworkResultSerialization.swift */; };
-		D5B9651F1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965181C922BDC0099D2F9 /* NetworkResultSerialization.swift */; };
-		D5B965201C922BDC0099D2F9 /* NetworkResultValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965191C922BDC0099D2F9 /* NetworkResultValidation.swift */; };
-		D5B965211C922BDC0099D2F9 /* NetworkResultValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965191C922BDC0099D2F9 /* NetworkResultValidation.swift */; };
+		D5B9651C1C922BDC0099D2F9 /* Wave.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965171C922BDC0099D2F9 /* Wave.swift */; };
+		D5B9651D1C922BDC0099D2F9 /* Wave.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965171C922BDC0099D2F9 /* Wave.swift */; };
+		D5B9651E1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965181C922BDC0099D2F9 /* WaveSerialization.swift */; };
+		D5B9651F1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965181C922BDC0099D2F9 /* WaveSerialization.swift */; };
+		D5B965201C922BDC0099D2F9 /* WaveValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965191C922BDC0099D2F9 /* WaveValidation.swift */; };
+		D5B965211C922BDC0099D2F9 /* WaveValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965191C922BDC0099D2F9 /* WaveValidation.swift */; };
 		D5B965241C922C1F0099D2F9 /* ETagStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965231C922C1F0099D2F9 /* ETagStorageSpec.swift */; };
 		D5B965251C922C1F0099D2F9 /* ETagStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965231C922C1F0099D2F9 /* ETagStorageSpec.swift */; };
 		D5B9652A1C922C420099D2F9 /* MIMETypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965261C922C420099D2F9 /* MIMETypeSpec.swift */; };
 		D5B9652B1C922C420099D2F9 /* MIMETypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965261C922C420099D2F9 /* MIMETypeSpec.swift */; };
-		D5B9652C1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965271C922C420099D2F9 /* NetworkResultSerializationSpec.swift */; };
-		D5B9652D1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965271C922C420099D2F9 /* NetworkResultSerializationSpec.swift */; };
-		D5B9652E1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965281C922C420099D2F9 /* NetworkResultSpec.swift */; };
-		D5B9652F1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965281C922C420099D2F9 /* NetworkResultSpec.swift */; };
-		D5B965301C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965291C922C420099D2F9 /* NetworkResultValidationSpec.swift */; };
-		D5B965311C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965291C922C420099D2F9 /* NetworkResultValidationSpec.swift */; };
+		D5B9652C1C922C420099D2F9 /* WaveSerializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965271C922C420099D2F9 /* WaveSerializationSpec.swift */; };
+		D5B9652D1C922C420099D2F9 /* WaveSerializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965271C922C420099D2F9 /* WaveSerializationSpec.swift */; };
+		D5B9652E1C922C420099D2F9 /* WaveSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965281C922C420099D2F9 /* WaveSpec.swift */; };
+		D5B9652F1C922C420099D2F9 /* WaveSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965281C922C420099D2F9 /* WaveSpec.swift */; };
+		D5B965301C922C420099D2F9 /* WaveValidationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965291C922C420099D2F9 /* WaveValidationSpec.swift */; };
+		D5B965311C922C420099D2F9 /* WaveValidationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965291C922C420099D2F9 /* WaveValidationSpec.swift */; };
 		D5B965351C922C500099D2F9 /* ContentTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965321C922C500099D2F9 /* ContentTypeSpec.swift */; };
 		D5B965361C922C500099D2F9 /* ContentTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965321C922C500099D2F9 /* ContentTypeSpec.swift */; };
 		D5B965371C922C500099D2F9 /* SessionConfigurationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965331C922C500099D2F9 /* SessionConfigurationSpec.swift */; };
@@ -192,14 +192,14 @@
 		D5B9650B1C922BCF0099D2F9 /* SessionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConfiguration.swift; sourceTree = "<group>"; };
 		D5B9650C1C922BCF0099D2F9 /* URLStringConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLStringConvertible.swift; sourceTree = "<group>"; };
 		D5B965161C922BDC0099D2F9 /* MIMEType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
-		D5B965171C922BDC0099D2F9 /* NetworkResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
-		D5B965181C922BDC0099D2F9 /* NetworkResultSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResultSerialization.swift; sourceTree = "<group>"; };
-		D5B965191C922BDC0099D2F9 /* NetworkResultValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResultValidation.swift; sourceTree = "<group>"; };
+		D5B965171C922BDC0099D2F9 /* Wave.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wave.swift; sourceTree = "<group>"; };
+		D5B965181C922BDC0099D2F9 /* WaveSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaveSerialization.swift; sourceTree = "<group>"; };
+		D5B965191C922BDC0099D2F9 /* WaveValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaveValidation.swift; sourceTree = "<group>"; };
 		D5B965231C922C1F0099D2F9 /* ETagStorageSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETagStorageSpec.swift; sourceTree = "<group>"; };
 		D5B965261C922C420099D2F9 /* MIMETypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MIMETypeSpec.swift; sourceTree = "<group>"; };
-		D5B965271C922C420099D2F9 /* NetworkResultSerializationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResultSerializationSpec.swift; sourceTree = "<group>"; };
-		D5B965281C922C420099D2F9 /* NetworkResultSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResultSpec.swift; sourceTree = "<group>"; };
-		D5B965291C922C420099D2F9 /* NetworkResultValidationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResultValidationSpec.swift; sourceTree = "<group>"; };
+		D5B965271C922C420099D2F9 /* WaveSerializationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaveSerializationSpec.swift; sourceTree = "<group>"; };
+		D5B965281C922C420099D2F9 /* WaveSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaveSpec.swift; sourceTree = "<group>"; };
+		D5B965291C922C420099D2F9 /* WaveValidationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaveValidationSpec.swift; sourceTree = "<group>"; };
 		D5B965321C922C500099D2F9 /* ContentTypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentTypeSpec.swift; sourceTree = "<group>"; };
 		D5B965331C922C500099D2F9 /* SessionConfigurationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConfigurationSpec.swift; sourceTree = "<group>"; };
 		D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLStringConvertibleSpec.swift; sourceTree = "<group>"; };
@@ -398,9 +398,9 @@
 			isa = PBXGroup;
 			children = (
 				D5B965161C922BDC0099D2F9 /* MIMEType.swift */,
-				D5B965171C922BDC0099D2F9 /* NetworkResult.swift */,
-				D5B965181C922BDC0099D2F9 /* NetworkResultSerialization.swift */,
-				D5B965191C922BDC0099D2F9 /* NetworkResultValidation.swift */,
+				D5B965171C922BDC0099D2F9 /* Wave.swift */,
+				D5B965181C922BDC0099D2F9 /* WaveSerialization.swift */,
+				D5B965191C922BDC0099D2F9 /* WaveValidation.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -409,9 +409,9 @@
 			isa = PBXGroup;
 			children = (
 				D5B965261C922C420099D2F9 /* MIMETypeSpec.swift */,
-				D5B965271C922C420099D2F9 /* NetworkResultSerializationSpec.swift */,
-				D5B965281C922C420099D2F9 /* NetworkResultSpec.swift */,
-				D5B965291C922C420099D2F9 /* NetworkResultValidationSpec.swift */,
+				D5B965281C922C420099D2F9 /* WaveSpec.swift */,
+				D5B965271C922C420099D2F9 /* WaveSerializationSpec.swift */,
+				D5B965291C922C420099D2F9 /* WaveValidationSpec.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -787,14 +787,14 @@
 				DAEE2BAE1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
 				D5B965131C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */,
 				DAA50FFB1C9A1EBB00D01F78 /* TaskRunning.swift in Sources */,
-				D5B9651C1C922BDC0099D2F9 /* NetworkResult.swift in Sources */,
+				D5B9651C1C922BDC0099D2F9 /* Wave.swift in Sources */,
 				D503D38D1C8DA7730009BDAD /* Serializing.swift in Sources */,
 				D5B964F51C92125E0099D2F9 /* Requestable.swift in Sources */,
 				D5B965111C922BCF0099D2F9 /* SessionConfiguration.swift in Sources */,
 				D5B965041C9225720099D2F9 /* ETagStorage.swift in Sources */,
 				D5B9650F1C922BCF0099D2F9 /* Method.swift in Sources */,
 				DAA50FF11C97738400D01F78 /* Header.swift in Sources */,
-				D5B965201C922BDC0099D2F9 /* NetworkResultValidation.swift in Sources */,
+				D5B965201C922BDC0099D2F9 /* WaveValidation.swift in Sources */,
 				DAC92A091C7F961900F01940 /* FormURLEncoder.swift in Sources */,
 				DAC92A061C7F90B400F01940 /* Malibu.swift in Sources */,
 				DA5B4D0A1C8E59A2004E21ED /* Networking.swift in Sources */,
@@ -803,7 +803,7 @@
 				DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */,
 				DAA510021C9A2D3C00D01F78 /* Mock.swift in Sources */,
 				D5B964F21C9211AF0099D2F9 /* Message.swift in Sources */,
-				D5B9651E1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */,
+				D5B9651E1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
 				D5EB7C601CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* Error.swift in Sources */,
 				D5B9650D1C922BCF0099D2F9 /* ContentType.swift in Sources */,
@@ -827,7 +827,7 @@
 				D5B9653C1C92340C0099D2F9 /* UtilsSpec.swift in Sources */,
 				DAEE2BB71C7F8C5D0000FB12 /* JSONParameterEncoderSpec.swift in Sources */,
 				DAC92A131C7FCF9400F01940 /* MalibuSpec.swift in Sources */,
-				D5B9652C1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */,
+				D5B9652C1C922C420099D2F9 /* WaveSerializationSpec.swift in Sources */,
 				D5B964EE1C916CBF0099D2F9 /* Mocks.swift in Sources */,
 				DA5B4D131C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
 				D527ED8C1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */,
@@ -842,11 +842,11 @@
 				D5B965351C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
 				D5EB7C6C1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */,
 				D527ED931C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */,
-				D5B9652E1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
+				D5B9652E1C922C420099D2F9 /* WaveSpec.swift in Sources */,
 				D527ED891C9B6B0F0092AD6B /* TaskRunningSpec.swift in Sources */,
 				D549C85C1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */,
-				D5B965301C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
+				D5B965301C922C420099D2F9 /* WaveValidationSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -866,14 +866,14 @@
 				DAEE2BAF1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
 				D5B965141C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */,
 				DAA50FFC1C9A1EBB00D01F78 /* TaskRunning.swift in Sources */,
-				D5B9651D1C922BDC0099D2F9 /* NetworkResult.swift in Sources */,
+				D5B9651D1C922BDC0099D2F9 /* Wave.swift in Sources */,
 				D503D38E1C8DA7730009BDAD /* Serializing.swift in Sources */,
 				D5B964F61C92125E0099D2F9 /* Requestable.swift in Sources */,
 				D5B965121C922BCF0099D2F9 /* SessionConfiguration.swift in Sources */,
 				D5B965051C9225720099D2F9 /* ETagStorage.swift in Sources */,
 				D5B965101C922BCF0099D2F9 /* Method.swift in Sources */,
 				DAA50FF21C97738400D01F78 /* Header.swift in Sources */,
-				D5B965211C922BDC0099D2F9 /* NetworkResultValidation.swift in Sources */,
+				D5B965211C922BDC0099D2F9 /* WaveValidation.swift in Sources */,
 				DAC92A0A1C7F961900F01940 /* FormURLEncoder.swift in Sources */,
 				DAC92A071C7F90B400F01940 /* Malibu.swift in Sources */,
 				DA5B4D0B1C8E59A2004E21ED /* Networking.swift in Sources */,
@@ -882,7 +882,7 @@
 				DA5B4CF01C8E5553004E21ED /* StringSerializer.swift in Sources */,
 				DAA510031C9A2D3C00D01F78 /* Mock.swift in Sources */,
 				D5B964F31C9211AF0099D2F9 /* Message.swift in Sources */,
-				D5B9651F1C922BDC0099D2F9 /* NetworkResultSerialization.swift in Sources */,
+				D5B9651F1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
 				D5EB7C611CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* Error.swift in Sources */,
 				D5B9650E1C922BCF0099D2F9 /* ContentType.swift in Sources */,
@@ -906,7 +906,7 @@
 				D5B9653D1C92340C0099D2F9 /* UtilsSpec.swift in Sources */,
 				DAEE2BB81C7F8C5E0000FB12 /* JSONParameterEncoderSpec.swift in Sources */,
 				DAC92A141C7FCF9500F01940 /* MalibuSpec.swift in Sources */,
-				D5B9652D1C922C420099D2F9 /* NetworkResultSerializationSpec.swift in Sources */,
+				D5B9652D1C922C420099D2F9 /* WaveSerializationSpec.swift in Sources */,
 				D5B964EF1C916CBF0099D2F9 /* Mocks.swift in Sources */,
 				DA5B4D141C8E5A26004E21ED /* NetworkingSpec.swift in Sources */,
 				D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */,
@@ -921,11 +921,11 @@
 				D5B965361C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
 				D5EB7C6D1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */,
 				D527ED941C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */,
-				D5B9652F1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
+				D5B9652F1C922C420099D2F9 /* WaveSpec.swift in Sources */,
 				D527ED8A1C9B6B0F0092AD6B /* TaskRunningSpec.swift in Sources */,
 				D549C85D1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */,
-				D5B965311C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
+				D5B965311C922C420099D2F9 /* WaveValidationSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		D503D3911C8DA95B0009BDAD /* JSONSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */; };
 		D503D3A51C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
 		D503D3A61C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
-		D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
-		D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */; };
+		D527ED891C9B6B0F0092AD6B /* TaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* TaskRunningSpec.swift */; };
+		D527ED8A1C9B6B0F0092AD6B /* TaskRunningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED881C9B6B0F0092AD6B /* TaskRunningSpec.swift */; };
 		D527ED8C1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
 		D527ED8D1C9B72450092AD6B /* SessionDataTaskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */; };
 		D527ED901C9B73D80092AD6B /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED8F1C9B73D80092AD6B /* MockSpec.swift */; };
@@ -82,6 +82,8 @@
 		D5B9653A1C922C500099D2F9 /* URLStringConvertibleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */; };
 		D5B9653C1C92340C0099D2F9 /* UtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */; };
 		D5B9653D1C92340C0099D2F9 /* UtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */; };
+		D5C1D06F1CB3D49F00A076D6 /* Ride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C1D06E1CB3D49F00A076D6 /* Ride.swift */; };
+		D5C1D0701CB3D49F00A076D6 /* Ride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C1D06E1CB3D49F00A076D6 /* Ride.swift */; };
 		D5C6294A1C3A7FAA007F7B7C /* Malibu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Malibu.framework */; };
 		D5C629771C3A878E007F7B7C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629751C3A878E007F7B7C /* Quick.framework */; };
 		D5C629781C3A878E007F7B7C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629761C3A878E007F7B7C /* Nimble.framework */; };
@@ -113,8 +115,8 @@
 		DAA50FF51C9786BE00D01F78 /* HeaderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */; };
 		DAA50FF81C9A1E8800D01F78 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */; };
 		DAA50FF91C9A1E8800D01F78 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */; };
-		DAA50FFB1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */; };
-		DAA50FFC1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */; };
+		DAA50FFB1C9A1EBB00D01F78 /* TaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* TaskRunning.swift */; };
+		DAA50FFC1C9A1EBB00D01F78 /* TaskRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA50FFA1C9A1EBB00D01F78 /* TaskRunning.swift */; };
 		DAA510021C9A2D3C00D01F78 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* Mock.swift */; };
 		DAA510031C9A2D3C00D01F78 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510011C9A2D3C00D01F78 /* Mock.swift */; };
 		DAA510051C9A2D5800D01F78 /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA510041C9A2D5800D01F78 /* MockDataTask.swift */; };
@@ -166,7 +168,7 @@
 		D503D38C1C8DA7730009BDAD /* Serializing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializing.swift; sourceTree = "<group>"; };
 		D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
-		D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunningSpec.swift; sourceTree = "<group>"; };
+		D527ED881C9B6B0F0092AD6B /* TaskRunningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskRunningSpec.swift; sourceTree = "<group>"; };
 		D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskSpec.swift; sourceTree = "<group>"; };
 		D527ED8F1C9B73D80092AD6B /* MockSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSpec.swift; sourceTree = "<group>"; };
 		D527ED921C9B77150092AD6B /* MockDataTaskSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataTaskSpec.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 		D5B965331C922C500099D2F9 /* SessionConfigurationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConfigurationSpec.swift; sourceTree = "<group>"; };
 		D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLStringConvertibleSpec.swift; sourceTree = "<group>"; };
 		D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilsSpec.swift; sourceTree = "<group>"; };
+		D5C1D06E1CB3D49F00A076D6 /* Ride.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ride.swift; sourceTree = "<group>"; };
 		D5C629401C3A7FAA007F7B7C /* Malibu.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Malibu.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C629491C3A7FAA007F7B7C /* Malibu-Mac-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Malibu-Mac-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C629751C3A878E007F7B7C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
@@ -224,7 +227,7 @@
 		DAA50FF01C97738400D01F78 /* Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		DAA50FF31C9786BE00D01F78 /* HeaderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderSpec.swift; sourceTree = "<group>"; };
 		DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTask.swift; sourceTree = "<group>"; };
-		DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTaskRunning.swift; sourceTree = "<group>"; };
+		DAA50FFA1C9A1EBB00D01F78 /* TaskRunning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskRunning.swift; sourceTree = "<group>"; };
 		DAA510011C9A2D3C00D01F78 /* Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		DAA510041C9A2D5800D01F78 /* MockDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataTask.swift; sourceTree = "<group>"; };
 		DAC92A051C7F90B400F01940 /* Malibu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Malibu.swift; sourceTree = "<group>"; };
@@ -301,7 +304,7 @@
 		D527ED871C9B6AAD0092AD6B /* Tasks */ = {
 			isa = PBXGroup;
 			children = (
-				D527ED881C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift */,
+				D527ED881C9B6B0F0092AD6B /* TaskRunningSpec.swift */,
 				D527ED8B1C9B72450092AD6B /* SessionDataTaskSpec.swift */,
 			);
 			path = Tasks;
@@ -371,6 +374,7 @@
 				D5B964F41C92125E0099D2F9 /* Requestable.swift */,
 				D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */,
 				D5EB7C5F1CB01E73003A3BA9 /* ETagPolicy.swift */,
+				D5C1D06E1CB3D49F00A076D6 /* Ride.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -473,7 +477,7 @@
 		DAA50FF61C9A1D8800D01F78 /* Tasks */ = {
 			isa = PBXGroup;
 			children = (
-				DAA50FFA1C9A1EBB00D01F78 /* NetworkTaskRunning.swift */,
+				DAA50FFA1C9A1EBB00D01F78 /* TaskRunning.swift */,
 				DAA50FF71C9A1E8800D01F78 /* SessionDataTask.swift */,
 			);
 			path = Tasks;
@@ -782,7 +786,7 @@
 				DAC92A361C87B92200F01940 /* Validating.swift in Sources */,
 				DAEE2BAE1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
 				D5B965131C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */,
-				DAA50FFB1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */,
+				DAA50FFB1C9A1EBB00D01F78 /* TaskRunning.swift in Sources */,
 				D5B9651C1C922BDC0099D2F9 /* NetworkResult.swift in Sources */,
 				D503D38D1C8DA7730009BDAD /* Serializing.swift in Sources */,
 				D5B964F51C92125E0099D2F9 /* Requestable.swift in Sources */,
@@ -803,6 +807,7 @@
 				D5EB7C601CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* Error.swift in Sources */,
 				D5B9650D1C922BCF0099D2F9 /* ContentType.swift in Sources */,
+				D5C1D06F1CB3D49F00A076D6 /* Ride.swift in Sources */,
 				D5B9651A1C922BDC0099D2F9 /* MIMEType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -838,7 +843,7 @@
 				D5EB7C6C1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */,
 				D527ED931C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */,
 				D5B9652E1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
-				D527ED891C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
+				D527ED891C9B6B0F0092AD6B /* TaskRunningSpec.swift in Sources */,
 				D549C85C1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */,
 				D5B965301C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,
@@ -860,7 +865,7 @@
 				DAC92A371C87B92200F01940 /* Validating.swift in Sources */,
 				DAEE2BAF1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
 				D5B965141C922BCF0099D2F9 /* URLStringConvertible.swift in Sources */,
-				DAA50FFC1C9A1EBB00D01F78 /* NetworkTaskRunning.swift in Sources */,
+				DAA50FFC1C9A1EBB00D01F78 /* TaskRunning.swift in Sources */,
 				D5B9651D1C922BDC0099D2F9 /* NetworkResult.swift in Sources */,
 				D503D38E1C8DA7730009BDAD /* Serializing.swift in Sources */,
 				D5B964F61C92125E0099D2F9 /* Requestable.swift in Sources */,
@@ -881,6 +886,7 @@
 				D5EB7C611CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* Error.swift in Sources */,
 				D5B9650E1C922BCF0099D2F9 /* ContentType.swift in Sources */,
+				D5C1D0701CB3D49F00A076D6 /* Ride.swift in Sources */,
 				D5B9651B1C922BDC0099D2F9 /* MIMEType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -916,7 +922,7 @@
 				D5EB7C6D1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */,
 				D527ED941C9B77150092AD6B /* MockDataTaskSpec.swift in Sources */,
 				D5B9652F1C922C420099D2F9 /* NetworkResultSpec.swift in Sources */,
-				D527ED8A1C9B6B0F0092AD6B /* NetworkTaskRunningSpec.swift in Sources */,
+				D527ED8A1C9B6B0F0092AD6B /* TaskRunningSpec.swift in Sources */,
 				D549C85D1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */,
 				D5B965311C922C420099D2F9 /* NetworkResultValidationSpec.swift in Sources */,

--- a/MalibuTests/Helpers/Mocks.swift
+++ b/MalibuTests/Helpers/Mocks.swift
@@ -42,7 +42,7 @@ struct HEADRequest: HEADRequestable {
 
 class TestNetworkTask: TaskRunning {
   let URLRequest: NSURLRequest
-  let promise: Promise<NetworkResult>
+  let promise: Promise<Wave>
   let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
   let response: NSHTTPURLResponse
 
@@ -50,7 +50,7 @@ class TestNetworkTask: TaskRunning {
 
   init() {
     URLRequest = try! GETRequest().toURLRequest()
-    promise = Promise<NetworkResult>()
+    promise = Promise<Wave>()
     response = NSHTTPURLResponse(URL: URLRequest.URL!, statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
   }
 

--- a/MalibuTests/Helpers/Mocks.swift
+++ b/MalibuTests/Helpers/Mocks.swift
@@ -40,7 +40,7 @@ struct HEADRequest: HEADRequestable {
 
 // MARK: - Tasks
 
-class TestNetworkTask: NetworkTaskRunning {
+class TestNetworkTask: TaskRunning {
   let URLRequest: NSURLRequest
   let promise: Promise<NetworkResult>
   let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
@@ -56,7 +56,8 @@ class TestNetworkTask: NetworkTaskRunning {
 
   // MARK: - NetworkTaskRunning
 
-  func run() {
+  func run() -> Ride {
     process(data, response: response, error: nil)
+    return Ride(promise: promise)
   }
 }

--- a/MalibuTests/Helpers/NetworkPromiseSpec.swift
+++ b/MalibuTests/Helpers/NetworkPromiseSpec.swift
@@ -4,7 +4,7 @@ import Quick
 import Nimble
 
 protocol NetworkPromiseSpec {
-  var networkPromise: Promise<NetworkResult>! { get }
+  var networkPromise: Promise<Wave>! { get }
   var request: NSURLRequest! { get }
   var data: NSData! { get }
 }
@@ -32,21 +32,21 @@ extension NetworkPromiseSpec where Self: QuickSpec {
       expectation.fulfill()
     })
 
-    networkPromise.resolve(NetworkResult(data: data, request: request, response: response))
+    networkPromise.resolve(Wave(data: data, request: request, response: response))
 
     self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }
 
   func testSucceededPromise<T>(promise: Promise<T>, response: NSHTTPURLResponse, validation: ((T) -> Void)? = nil) {
     let expectation = self.expectationWithDescription("Validation response success")
-    let networkResult = NetworkResult(data: data, request: request, response: response)
+    let wave = Wave(data: data, request: request, response: response)
 
     promise.done({ result in
       validation?(result)
       expectation.fulfill()
     })
 
-    networkPromise.resolve(networkResult)
+    networkPromise.resolve(wave)
 
     self.waitForExpectationsWithTimeout(4.0, handler:nil)
   }

--- a/MalibuTests/Specs/Mocks/MockDataTaskSpec.swift
+++ b/MalibuTests/Specs/Mocks/MockDataTaskSpec.swift
@@ -12,7 +12,7 @@ class MockDataSpec: QuickSpec {
       var request: Requestable!
       var URLRequest: NSURLRequest!
       var response: NSHTTPURLResponse!
-      var promise: Promise<NetworkResult>!
+      var promise: Promise<Wave>!
       let data = "test".dataUsingEncoding(NSUTF32StringEncoding)
       let error = Error.JSONArraySerializationFailed
 
@@ -21,7 +21,7 @@ class MockDataSpec: QuickSpec {
         URLRequest = try! request.toURLRequest()
         response = NSHTTPURLResponse(URL: NSURL(string: "http://hyper.no")!,
           statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
-        promise = Promise<NetworkResult>()
+        promise = Promise<Wave>()
       }
 
       describe("#init") {

--- a/MalibuTests/Specs/Response/WaveSerializationSpec.swift
+++ b/MalibuTests/Specs/Response/WaveSerializationSpec.swift
@@ -3,14 +3,14 @@ import When
 import Quick
 import Nimble
 
-class NetworkResultSerializationSpec: QuickSpec, NetworkPromiseSpec {
+class WaveSerializationSpec: QuickSpec, NetworkPromiseSpec {
 
-  var networkPromise: Promise<NetworkResult>!
+  var networkPromise: Promise<Wave>!
   var request: NSURLRequest!
   var data: NSData!
 
   override func spec() {
-    describe("NetworkResultSerialization") {
+    describe("WaveSerialization") {
 
       let URL = NSURL(string: "http://hyper.no")!
       let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
@@ -18,7 +18,7 @@ class NetworkResultSerializationSpec: QuickSpec, NetworkPromiseSpec {
       // MARK: - Specs
 
       beforeEach {
-        self.networkPromise = Promise<NetworkResult>()
+        self.networkPromise = Promise<Wave>()
         self.request = NSURLRequest(URL: NSURL(string: "http://hyper.no")!)
         self.data = try! NSJSONSerialization.dataWithJSONObject([["name": "Taylor"]],
           options: NSJSONWritingOptions())

--- a/MalibuTests/Specs/Response/WaveSpec.swift
+++ b/MalibuTests/Specs/Response/WaveSpec.swift
@@ -3,10 +3,10 @@ import When
 import Quick
 import Nimble
 
-class NetworkResultSpec: QuickSpec {
+class WaveSpec: QuickSpec {
 
   override func spec() {
-    describe("NetworkResult") {
+    describe("Wave") {
       let URL = NSURL(string: "http://hyper.no")!
       let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
       var request: NSURLRequest!
@@ -20,7 +20,7 @@ class NetworkResultSpec: QuickSpec {
 
       describe("#init") {
         it("sets data, request and response parameters to instance vars") {
-          let result = NetworkResult(data: data, request: request, response: response)
+          let result = Wave(data: data, request: request, response: response)
 
           expect(result.data).to(equal(data))
           expect(result.request).to(equal(request))

--- a/MalibuTests/Specs/Response/WaveValidationSpec.swift
+++ b/MalibuTests/Specs/Response/WaveValidationSpec.swift
@@ -3,14 +3,14 @@ import When
 import Quick
 import Nimble
 
-class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
+class WaveValidationSpec: QuickSpec, NetworkPromiseSpec {
 
-  var networkPromise: Promise<NetworkResult>!
+  var networkPromise: Promise<Wave>!
   var request: NSURLRequest!
   var data: NSData!
 
   override func spec() {
-    describe("NetworkResultValidation") {
+    describe("WaveValidation") {
       let URL = NSURL(string: "http://hyper.no")!
       let response = NSHTTPURLResponse(URL: URL, statusCode: 200, HTTPVersion: "HTTP/2.0", headerFields: nil)!
       let failedResponse = NSHTTPURLResponse(URL: URL, statusCode: 404, HTTPVersion: "HTTP/2.0", headerFields: nil)!
@@ -18,7 +18,7 @@ class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
       // MARK: - Specs
 
       beforeEach {
-        self.networkPromise = Promise<NetworkResult>()
+        self.networkPromise = Promise<Wave>()
         self.request = NSURLRequest(URL: NSURL(string: "http://hyper.no")!)
         self.data = try! NSJSONSerialization.dataWithJSONObject([["name": "Taylor"]],
           options: NSJSONWritingOptions())
@@ -26,7 +26,7 @@ class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
 
       describe("#validate:validator") {
         let validator = StatusCodeValidator(statusCodes: [200])
-        var promise: Promise<NetworkResult>!
+        var promise: Promise<Wave>!
 
         beforeEach {
           promise = self.networkPromise.validate(validator)
@@ -53,7 +53,7 @@ class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
       }
 
       describe("#validate:statusCodes") {
-        var promise: Promise<NetworkResult>!
+        var promise: Promise<Wave>!
 
         beforeEach {
           promise = self.networkPromise.validate(statusCodes: [200])
@@ -80,7 +80,7 @@ class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
       }
 
       describe("#validate:contentTypes") {
-        var promise: Promise<NetworkResult>!
+        var promise: Promise<Wave>!
 
         beforeEach {
           promise = self.networkPromise.validate(contentTypes: ["application/json; charset=utf-8"])
@@ -113,7 +113,7 @@ class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
       }
 
       describe("#validate") {
-        var promise: Promise<NetworkResult>!
+        var promise: Promise<Wave>!
 
         context("with no accept header in the request") {
           beforeEach {
@@ -141,7 +141,7 @@ class NetworkResultValidationSpec: QuickSpec, NetworkPromiseSpec {
         }
 
         context("with accept header in the request") {
-          var promise: Promise<NetworkResult>!
+          var promise: Promise<Wave>!
 
           beforeEach {
             let request = NSMutableURLRequest(URL: URL)

--- a/MalibuTests/Specs/Tasks/SessionDataTaskSpec.swift
+++ b/MalibuTests/Specs/Tasks/SessionDataTaskSpec.swift
@@ -10,7 +10,7 @@ class SessionDataTaskSpec: QuickSpec {
       var task: SessionDataTask!
       let session = NSURLSession()
       let URLRequest = try! GETRequest().toURLRequest()
-      let promise = Promise<NetworkResult>()
+      let promise = Promise<Wave>()
 
       describe("#init") {
         beforeEach {

--- a/MalibuTests/Specs/Tasks/TaskRunningSpec.swift
+++ b/MalibuTests/Specs/Tasks/TaskRunningSpec.swift
@@ -3,10 +3,10 @@ import Quick
 import Nimble
 import When
 
-class NetworkTaskRunningSpec: QuickSpec {
+class TaskRunningSpec: QuickSpec {
 
   override func spec() {
-    describe("NetworkTaskRunning") {
+    describe("TaskRunning") {
       var task: TestNetworkTask!
 
       beforeEach {

--- a/MalibuTests/Specs/Validation/ContentTypeValidatorSpec.swift
+++ b/MalibuTests/Specs/Validation/ContentTypeValidatorSpec.swift
@@ -21,7 +21,7 @@ class ContentTypeValidatorSpec: QuickSpec {
           it("does not throw an error") {
             let HTTPResponse = NSHTTPURLResponse(URL: URL, MIMEType: contentType,
               expectedContentLength: 10, textEncodingName: nil)
-            let result = NetworkResult(data: data, request: request, response: HTTPResponse)
+            let result = Wave(data: data, request: request, response: HTTPResponse)
 
             expect{ try validator.validate(result) }.toNot(throwError())
           }
@@ -31,7 +31,7 @@ class ContentTypeValidatorSpec: QuickSpec {
           it("throws an error") {
             let HTTPResponse = NSHTTPURLResponse(URL: URL, MIMEType: "text/html; charset=utf-8",
               expectedContentLength: 100, textEncodingName: nil)
-            let result = NetworkResult(data: data, request: request, response: HTTPResponse)
+            let result = Wave(data: data, request: request, response: HTTPResponse)
 
             expect{ try validator.validate(result) }.to(throwError())
           }

--- a/MalibuTests/Specs/Validation/StatusCodeVadatorSpec.swift
+++ b/MalibuTests/Specs/Validation/StatusCodeVadatorSpec.swift
@@ -20,7 +20,7 @@ class StatusCodeValidatorSpec: QuickSpec {
           it("does not throw an error") {
             let HTTPResponse = NSHTTPURLResponse(URL: URL, statusCode: 200,
               HTTPVersion: "HTTP/2.0", headerFields: nil)!
-            let result = NetworkResult(data: data, request: request, response: HTTPResponse)
+            let result = Wave(data: data, request: request, response: HTTPResponse)
 
             expect{ try validator.validate(result) }.toNot(throwError())
           }
@@ -30,7 +30,7 @@ class StatusCodeValidatorSpec: QuickSpec {
           it("throws an error") {
             let HTTPResponse = NSHTTPURLResponse(URL: URL, statusCode: 404,
               HTTPVersion: "HTTP/2.0", headerFields: nil)!
-            let result = NetworkResult(data: data, request: request, response: HTTPResponse)
+            let result = Wave(data: data, request: request, response: HTTPResponse)
 
             expect{ try validator.validate(result) }.to(throwError())
           }

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -41,26 +41,26 @@ public func register(mock mock: Mock) {
 
 // MARK: - Requests
 
-public func GET(request: GETRequestable) -> Promise<NetworkResult> {
+public func GET(request: GETRequestable) -> Ride {
   return backfootSurfer.GET(request)
 }
 
-public func POST(request: POSTRequestable) -> Promise<NetworkResult> {
+public func POST(request: POSTRequestable) -> Ride {
   return backfootSurfer.POST(request)
 }
 
-public func PUT(request: PUTRequestable) -> Promise<NetworkResult> {
+public func PUT(request: PUTRequestable) -> Ride {
   return backfootSurfer.PUT(request)
 }
 
-public func PATCH(request: PATCHRequestable) -> Promise<NetworkResult> {
+public func PATCH(request: PATCHRequestable) -> Ride {
   return backfootSurfer.PATCH(request)
 }
 
-public func DELETE(request: DELETERequestable) -> Promise<NetworkResult> {
+public func DELETE(request: DELETERequestable) -> Ride {
   return backfootSurfer.DELETE(request)
 }
 
-public func HEAD(request: HEADRequestable) -> Promise<NetworkResult> {
+public func HEAD(request: HEADRequestable) -> Ride {
   return backfootSurfer.HEAD(request)
 }

--- a/Sources/Mocks/MockDataTask.swift
+++ b/Sources/Mocks/MockDataTask.swift
@@ -1,7 +1,7 @@
 import Foundation
 import When
 
-class MockDataTask: NetworkTaskRunning {
+class MockDataTask: TaskRunning {
 
   let mock: Mock
   let URLRequest: NSURLRequest
@@ -17,7 +17,8 @@ class MockDataTask: NetworkTaskRunning {
 
   // MARK: - NetworkTaskRunning
 
-  func run() {
+  func run() -> Ride {
     process(mock.data, response: mock.response, error: mock.error)
+    return Ride(promise: promise)
   }
 }

--- a/Sources/Mocks/MockDataTask.swift
+++ b/Sources/Mocks/MockDataTask.swift
@@ -5,11 +5,11 @@ class MockDataTask: TaskRunning {
 
   let mock: Mock
   let URLRequest: NSURLRequest
-  let promise: Promise<NetworkResult>
+  let promise: Promise<Wave>
 
   // MARK: - Initialization
 
-  init(mock: Mock, URLRequest: NSURLRequest, promise: Promise<NetworkResult>) {
+  init(mock: Mock, URLRequest: NSURLRequest, promise: Promise<Wave>) {
     self.mock = mock
     self.URLRequest = URLRequest
     self.promise = promise

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -52,7 +52,7 @@ public class Networking: NSObject {
   // MARK: - Networking
 
   func execute(request: Requestable) -> Ride {
-    let promise = Promise<NetworkResult>()
+    let promise = Promise<Wave>()
     let URLRequest: NSMutableURLRequest
 
     do {
@@ -85,7 +85,7 @@ public class Networking: NSObject {
       task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
     }
 
-    let nextPromise = promise.then { result -> NetworkResult in
+    let nextPromise = promise.then { result -> Wave in
       self.saveEtag(request, response: result.response)
       return result
     }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -51,7 +51,7 @@ public class Networking: NSObject {
 
   // MARK: - Networking
 
-  func execute(request: Requestable) -> Promise<NetworkResult> {
+  func execute(request: Requestable) -> Ride {
     let promise = Promise<NetworkResult>()
     let URLRequest: NSMutableURLRequest
 
@@ -60,12 +60,12 @@ public class Networking: NSObject {
       URLRequest = try request.toURLRequest(baseURLString, additionalHeaders: requestHeaders)
     } catch {
       promise.reject(error)
-      return promise
+      return Ride(promise: promise)
     }
 
     preProcessRequest?(URLRequest)
 
-    let task: NetworkTaskRunning
+    let task: TaskRunning
 
     switch Malibu.mode {
     case .Regular:
@@ -79,7 +79,7 @@ public class Networking: NSObject {
     case .Fake:
       guard let mock = prepareMock(request) else {
         promise.reject(Error.NoMockProvided)
-        return promise
+        return Ride(promise: promise)
       }
 
       task = MockDataTask(mock: mock, URLRequest: URLRequest, promise: promise)
@@ -90,9 +90,10 @@ public class Networking: NSObject {
       return result
     }
 
-    task.run()
+    let ride = task.run()
+    ride.promise = nextPromise
 
-    return nextPromise
+    return ride
   }
 
   // MARK: - Authentication
@@ -144,27 +145,27 @@ public class Networking: NSObject {
 
 public extension Networking {
 
-  func GET(request: GETRequestable) -> Promise<NetworkResult> {
+  func GET(request: GETRequestable) -> Ride {
     return execute(request)
   }
 
-  func POST(request: POSTRequestable) -> Promise<NetworkResult> {
+  func POST(request: POSTRequestable) -> Ride {
     return execute(request)
   }
 
-  func PUT(request: PUTRequestable) -> Promise<NetworkResult> {
+  func PUT(request: PUTRequestable) -> Ride {
     return execute(request)
   }
 
-  func PATCH(request: PATCHRequestable) -> Promise<NetworkResult> {
+  func PATCH(request: PATCHRequestable) -> Ride {
     return execute(request)
   }
 
-  func DELETE(request: DELETERequestable) -> Promise<NetworkResult> {
+  func DELETE(request: DELETERequestable) -> Ride {
     return execute(request)
   }
 
-  func HEAD(request: HEADRequestable) -> Promise<NetworkResult> {
+  func HEAD(request: HEADRequestable) -> Ride {
     return execute(request)
   }
 }

--- a/Sources/Request/Ride.swift
+++ b/Sources/Request/Ride.swift
@@ -1,0 +1,18 @@
+import Foundation
+import When
+
+public class Ride {
+
+  public var promise: Promise<NetworkResult>
+  public var task: NSURLSessionTask?
+
+  public init(promise: Promise<NetworkResult>, task: NSURLSessionTask? = nil) {
+    self.promise = promise
+    self.task = task
+  }
+
+  public func cancel() {
+    task?.cancel()
+    task = nil
+  }
+}

--- a/Sources/Request/Ride.swift
+++ b/Sources/Request/Ride.swift
@@ -3,10 +3,10 @@ import When
 
 public class Ride {
 
-  public var promise: Promise<NetworkResult>
+  public var promise: Promise<Wave>
   public var task: NSURLSessionTask?
 
-  public init(promise: Promise<NetworkResult>, task: NSURLSessionTask? = nil) {
+  public init(promise: Promise<Wave>, task: NSURLSessionTask? = nil) {
     self.promise = promise
     self.task = task
   }

--- a/Sources/Response/Wave.swift
+++ b/Sources/Response/Wave.swift
@@ -1,7 +1,7 @@
 import Foundation
 import When
 
-public class NetworkResult: Equatable {
+public class Wave: Equatable {
 
   public let data: NSData
   public let request: NSURLRequest
@@ -16,7 +16,7 @@ public class NetworkResult: Equatable {
 
 // MARK: - Equatable
 
-public func ==(lhs: NetworkResult, rhs: NetworkResult) -> Bool {
+public func ==(lhs: Wave, rhs: Wave) -> Bool {
   return lhs.data == rhs.data
     && lhs.request == rhs.request
     && lhs.response == rhs.response

--- a/Sources/Response/WaveSerialization.swift
+++ b/Sources/Response/WaveSerialization.swift
@@ -3,7 +3,7 @@ import When
 
 // MARK: - Serialization
 
-public extension Promise where T: NetworkResult {
+public extension Promise where T: Wave {
 
   public func toData() -> Promise<NSData> {
     return then({ result -> NSData in

--- a/Sources/Response/WaveValidation.swift
+++ b/Sources/Response/WaveValidation.swift
@@ -3,25 +3,25 @@ import When
 
 // MARK: - Validations
 
-public extension Promise where T: NetworkResult {
+public extension Promise where T: Wave {
 
-  public func validate(validator: Validating) -> Promise<NetworkResult> {
-    return then({ result -> NetworkResult in
+  public func validate(validator: Validating) -> Promise<Wave> {
+    return then({ result -> Wave in
       try validator.validate(result)
       return result
     })
   }
 
-  public func validate<T: SequenceType where T.Generator.Element == Int>(statusCodes statusCodes: T) -> Promise<NetworkResult> {
+  public func validate<T: SequenceType where T.Generator.Element == Int>(statusCodes statusCodes: T) -> Promise<Wave> {
     return validate(StatusCodeValidator(statusCodes: statusCodes))
   }
 
-  public func validate<T : SequenceType where T.Generator.Element == String>(contentTypes contentTypes: T) -> Promise<NetworkResult> {
+  public func validate<T : SequenceType where T.Generator.Element == String>(contentTypes contentTypes: T) -> Promise<Wave> {
     return validate(ContentTypeValidator(contentTypes: contentTypes))
   }
 
-  public func validate() -> Promise<NetworkResult> {
-    return validate(statusCodes: 200..<300).then({ result -> NetworkResult in
+  public func validate() -> Promise<Wave> {
+    return validate(statusCodes: 200..<300).then({ result -> Wave in
       let contentTypes: [String]
 
       if let accept = result.request.valueForHTTPHeaderField("Accept") {

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -1,7 +1,7 @@
 import Foundation
 import When
 
-class SessionDataTask: NetworkTaskRunning {
+class SessionDataTask: TaskRunning {
 
   var session: NSURLSession
   var URLRequest: NSURLRequest
@@ -17,7 +17,10 @@ class SessionDataTask: NetworkTaskRunning {
 
   // MARK: - NetworkTaskRunning
 
-  func run() {
-    session.dataTaskWithRequest(URLRequest, completionHandler: process).resume()
+  func run() -> Ride {
+    let task = session.dataTaskWithRequest(URLRequest, completionHandler: process)
+    task.resume()
+
+    return Ride(promise: promise, task: task)
   }
 }

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -5,11 +5,11 @@ class SessionDataTask: TaskRunning {
 
   var session: NSURLSession
   var URLRequest: NSURLRequest
-  var promise: Promise<NetworkResult>
+  var promise: Promise<Wave>
 
   // MARK: - Initialization
 
-  init(session: NSURLSession, URLRequest: NSURLRequest, promise: Promise<NetworkResult>) {
+  init(session: NSURLSession, URLRequest: NSURLRequest, promise: Promise<Wave>) {
     self.session = session
     self.URLRequest = URLRequest
     self.promise = promise

--- a/Sources/Tasks/TaskRunning.swift
+++ b/Sources/Tasks/TaskRunning.swift
@@ -3,7 +3,7 @@ import When
 
 protocol TaskRunning: class {
   var URLRequest: NSURLRequest { get }
-  var promise: Promise<NetworkResult> { get }
+  var promise: Promise<Wave> { get }
 
   func run() -> Ride
 }
@@ -26,7 +26,7 @@ extension TaskRunning {
       return
     }
 
-    let result = NetworkResult(data: data, request: URLRequest, response: response)
+    let result = Wave(data: data, request: URLRequest, response: response)
     promise.resolve(result)
   }
 }

--- a/Sources/Tasks/TaskRunning.swift
+++ b/Sources/Tasks/TaskRunning.swift
@@ -1,14 +1,14 @@
 import Foundation
 import When
 
-protocol NetworkTaskRunning: class {
+protocol TaskRunning: class {
   var URLRequest: NSURLRequest { get }
   var promise: Promise<NetworkResult> { get }
 
-  func run()
+  func run() -> Ride
 }
 
-extension NetworkTaskRunning {
+extension TaskRunning {
 
   func process(data: NSData?, response: NSURLResponse?, error: ErrorType?) {
     if let error = error {

--- a/Sources/Validation/ContentTypeValidator.swift
+++ b/Sources/Validation/ContentTypeValidator.swift
@@ -12,7 +12,7 @@ public struct ContentTypeValidator<T : SequenceType where T.Generator.Element ==
 
   // MARK: - Validation
 
-  public func validate(result: NetworkResult) throws {
+  public func validate(result: Wave) throws {
     let response = result.response
 
     if let responseContentType = response.MIMEType,

--- a/Sources/Validation/StatusCodeValidator.swift
+++ b/Sources/Validation/StatusCodeValidator.swift
@@ -12,7 +12,7 @@ public struct StatusCodeValidator<T: SequenceType where T.Generator.Element == I
 
   // MARK: - Validation
 
-  public func validate(result: NetworkResult) throws {
+  public func validate(result: Wave) throws {
     guard statusCodes.contains(result.response.statusCode) else {
       throw Error.UnacceptableStatusCode(result.response.statusCode)
     }

--- a/Sources/Validation/Validating.swift
+++ b/Sources/Validation/Validating.swift
@@ -2,5 +2,5 @@ import Foundation
 import When
 
 public protocol Validating {
-  func validate(result: NetworkResult) throws
+  func validate(result: Wave) throws
 }


### PR DESCRIPTION
All the request functions return `Ride` object which you can use in the following way:

1) As promise:
```swift
let ride = Malibu.GET(Request(parameters: parameters))

ride.validate()
      .toJSONDictionary()
      .done({ data in
        print(data)
      })
      .fail({ error in
        print(error)
      })
```
2) As a task:
```swift
ride.cancel()
```

Also boring `NetworkResult` is renamed to `Wave`, so now we have `Promise<Wave>`.