### PR TITLE
Feature: logging

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		D560A2E51C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D560A2E31C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift */; };
 		D560A2E71C8C694100D4B640 /* ContentTypeValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D560A2E61C8C694100D4B640 /* ContentTypeValidatorSpec.swift */; };
 		D560A2E81C8C694100D4B640 /* ContentTypeValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D560A2E61C8C694100D4B640 /* ContentTypeValidatorSpec.swift */; };
+		D5A3DC881CD164750084F451 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A3DC871CD164750084F451 /* Logging.swift */; };
+		D5A3DC891CD164750084F451 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A3DC871CD164750084F451 /* Logging.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Malibu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Malibu.framework */; };
 		D5B964EE1C916CBF0099D2F9 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964ED1C916CBF0099D2F9 /* Mocks.swift */; };
 		D5B964EF1C916CBF0099D2F9 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B964ED1C916CBF0099D2F9 /* Mocks.swift */; };
@@ -181,6 +183,7 @@
 		D559C5E11CC0191700700B3C /* mock.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = mock.json; sourceTree = "<group>"; };
 		D560A2E31C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusCodeVadatorSpec.swift; sourceTree = "<group>"; };
 		D560A2E61C8C694100D4B640 /* ContentTypeValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentTypeValidatorSpec.swift; sourceTree = "<group>"; };
+		D5A3DC871CD164750084F451 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Malibu.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Malibu.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Malibu-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Malibu-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B964ED1C916CBF0099D2F9 /* Mocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
@@ -450,6 +453,7 @@
 				DAC92A051C7F90B400F01940 /* Malibu.swift */,
 				DA5B4D031C8E59A2004E21ED /* Networking.swift */,
 				DA5B4CF71C8E5936004E21ED /* Error.swift */,
+				D5A3DC871CD164750084F451 /* Logging.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -820,6 +824,7 @@
 				D5B9651E1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
 				D5EB7C601CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* Error.swift in Sources */,
+				D5A3DC881CD164750084F451 /* Logging.swift in Sources */,
 				D5B9650D1C922BCF0099D2F9 /* ContentType.swift in Sources */,
 				D5C1D06F1CB3D49F00A076D6 /* Ride.swift in Sources */,
 				D5B9651A1C922BDC0099D2F9 /* MIMEType.swift in Sources */,
@@ -899,6 +904,7 @@
 				D5B9651F1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
 				D5EB7C611CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* Error.swift in Sources */,
+				D5A3DC891CD164750084F451 /* Logging.swift in Sources */,
 				D5B9650E1C922BCF0099D2F9 /* ContentType.swift in Sources */,
 				D5C1D0701CB3D49F00A076D6 /* Ride.swift in Sources */,
 				D5B9651B1C922BDC0099D2F9 /* MIMEType.swift in Sources */,

--- a/Sources/Helpers/Utils.swift
+++ b/Sources/Helpers/Utils.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public struct Utils {
+struct Utils {
 
   // MARK: - Storage
 
-  public static let documentDirectory =  NSSearchPathForDirectoriesInDomains(.DocumentDirectory,
+  static let documentDirectory =  NSSearchPathForDirectoriesInDomains(.DocumentDirectory,
     .UserDomainMask, true).first!
 
-  public static var storageDirectory: String = {
+  static var storageDirectory: String = {
     let directory = "\(documentDirectory)/Malibu"
 
     do {
@@ -21,7 +21,7 @@ public struct Utils {
     return directory
   }()
 
-  public static func filePath(name: String) -> String {
+  static func filePath(name: String) -> String {
     return "\(Utils.storageDirectory)/\(name)"
   }
 }

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -2,15 +2,15 @@ import Foundation
 
 // MARK: - Logger
 
-public struct Logger {
+public class Logger {
 
   public enum Level {
     case Debug, Info, Error, Disabled
   }
 
   public var level: Level = .Disabled
-  public var errorLogger = ErrorLogger()
-  public var infoLogger = InfoLogger()
+  public var errorLogger: ErrorLogging = ErrorLogger()
+  public var infoLogger: InfoLogging = InfoLogger()
 
   var logErrors: Bool {
     return level == .Error || level == .Debug

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -1,0 +1,3 @@
+protocol Logging {
+  func logError(error: ErrorType)
+}

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+// MARK: - Logger
+
+public struct Logger {
+
+  public enum Level {
+    case Debug, Info, Error, Disabled
+  }
+
+  public var level: Level = .Disabled
+  public var errorLogger = ErrorLogger()
+  public var infoLogger = InfoLogger()
+
+  var logErrors: Bool {
+    return level == .Error || level == .Debug
+  }
+
+  var logInfo: Bool {
+    return level == .Info || level == .Debug
+  }
+}
+
 // MARK: - Errors
 
 public protocol ErrorLogging {

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -2,26 +2,26 @@ import Foundation
 
 // MARK: - Errors
 
-protocol ErrorLogging {
+public protocol ErrorLogging {
   func logError(error: ErrorType)
 }
 
-struct ErrorLogger: ErrorLogging {
+public struct ErrorLogger: ErrorLogging {
 
-  func logError(error: ErrorType) {
+  public func logError(error: ErrorType) {
     NSLog("\(error)")
   }
 }
 
-// MARK: - Requests
+// MARK: - Info
 
-protocol RequestLogging {
+public protocol InfoLogging {
   func logRequest(request: NSURLRequest)
 }
 
-struct RequestLogger: RequestLogging {
+public struct InfoLogger: InfoLogging {
 
-  func logRequest(request: NSURLRequest) {
+  public func logRequest(request: NSURLRequest) {
     guard let URLString = request.URL?.absoluteString else {
       return
     }

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -1,3 +1,31 @@
-protocol Logging {
+import Foundation
+
+// MARK: - Errors
+
+protocol ErrorLogging {
   func logError(error: ErrorType)
+}
+
+struct ErrorLogger: ErrorLogging {
+
+  func logError(error: ErrorType) {
+    NSLog("\(error)")
+  }
+}
+
+// MARK: - Requests
+
+protocol RequestLogging {
+  func logRequest(request: NSURLRequest)
+}
+
+struct RequestLogger: RequestLogging {
+
+  func logRequest(request: NSURLRequest) {
+    guard let URLString = request.URL?.absoluteString else {
+      return
+    }
+
+    NSLog("\(URLString)")
+  }
 }

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -5,6 +5,10 @@ public enum Mode {
   case Regular, Partial, Fake
 }
 
+public enum LoggingMode {
+  case Errors, Requests, All, None
+}
+
 // MARK: - Helpers
 
 var networkings = [String: Networking]()

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -5,19 +5,23 @@ public enum Mode {
   case Regular, Partial, Fake
 }
 
-public enum LoggingMode {
-  case Errors, Requests, All, None
+public enum LoggingLevel {
+  case Debug, Info, Error, Disabled
 }
 
 // MARK: - Helpers
 
 var networkings = [String: Networking]()
 
-// MARK: - Public
+// MARK: - Vars
 
 public var mode: Mode = .Regular
 public var backfootSurfer = Networking()
 public var parameterEncoders = [ContentType: ParameterEncoding]()
+public var loggingLevel: LoggingLevel = .Disabled
+public var errorLogger = ErrorLogger()
+public var infoLogger = InfoLogger()
+
 let boundary = "Malibu\(NSUUID().UUIDString)"
 
 // MARK: - Networkings

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -5,10 +5,6 @@ public enum Mode {
   case Regular, Partial, Fake
 }
 
-public enum LoggingLevel {
-  case Debug, Info, Error, Disabled
-}
-
 // MARK: - Helpers
 
 var networkings = [String: Networking]()
@@ -18,9 +14,7 @@ var networkings = [String: Networking]()
 public var mode: Mode = .Regular
 public var backfootSurfer = Networking()
 public var parameterEncoders = [ContentType: ParameterEncoding]()
-public var loggingLevel: LoggingLevel = .Disabled
-public var errorLogger = ErrorLogger()
-public var infoLogger = InfoLogger()
+public var logger = Logger()
 
 let boundary = "Malibu\(NSUUID().UUIDString)"
 

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -18,6 +18,10 @@ class SessionDataTask: TaskRunning {
   // MARK: - NetworkTaskRunning
 
   func run() -> Ride {
+    if loggingLevel == .Info || loggingLevel == .Debug {
+      infoLogger.logRequest(URLRequest)
+    }
+
     let task = session.dataTaskWithRequest(URLRequest, completionHandler: process)
     task.resume()
 

--- a/Sources/Tasks/SessionDataTask.swift
+++ b/Sources/Tasks/SessionDataTask.swift
@@ -18,8 +18,8 @@ class SessionDataTask: TaskRunning {
   // MARK: - NetworkTaskRunning
 
   func run() -> Ride {
-    if loggingLevel == .Info || loggingLevel == .Debug {
-      infoLogger.logRequest(URLRequest)
+    if logger.logInfo {
+      logger.infoLogger.logRequest(URLRequest)
     }
 
     let task = session.dataTaskWithRequest(URLRequest, completionHandler: process)


### PR DESCRIPTION
Now you can disable and enable logging and provide your own logging method:

```swift
// MARK: - Errors

struct CustomErrorLogger: ErrorLogging {
  func logError(error: ErrorType) {
    NSLog("\(error)")
  }
}

// MARK: - Info

struct CustomInfoLogger: InfoLogging {
  func logRequest(request: NSURLRequest) {
    guard let URLString = request.URL?.absoluteString else {
      return
    }

    NSLog("\(URLString)")
  }
}

Malibu.logger.infoLogger = CustomInfoLogger()
Malibu.logger.errorLogger = CustomInfoLogger()
Malibu.logger.level = .Debug
```

If you just set a logging level so something other than `.Disabled` and don't specify custom loggers, then defaults loggers will be used.