### PR TITLE
Update os info

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v4.0.1"
+github "Quick/Nimble" "v4.1.0"
 github "Quick/Quick" "v0.9.2"
 github "vadymmarkov/When" "1.0.4"

--- a/MalibuTests/Specs/Request/HeaderSpec.swift
+++ b/MalibuTests/Specs/Request/HeaderSpec.swift
@@ -32,7 +32,7 @@ class HeaderSpec: QuickSpec {
             let executable: AnyObject = info[kCFBundleExecutableKey as String] ?? "Unknown"
             let bundle: AnyObject = info[kCFBundleIdentifierKey as String] ?? "Unknown"
             let version: AnyObject = info[kCFBundleVersionKey as String] ?? "Unknown"
-            let os: AnyObject = NSProcessInfo.processInfo().operatingSystemVersionString ?? "Unknown"
+            let os: AnyObject = Utils.osInfo
             let mutableUserAgent = NSMutableString(
               string: "\(executable)/\(bundle) (\(version); OS \(os))") as CFMutableString
             let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString

--- a/Sources/Helpers/Utils.swift
+++ b/Sources/Helpers/Utils.swift
@@ -24,4 +24,25 @@ struct Utils {
   static func filePath(name: String) -> String {
     return "\(Utils.storageDirectory)/\(name)"
   }
+
+  // MARK: - OS
+
+  static var osName: String {
+    #if os(iOS)
+      return "iOS"
+    #elseif os(tvOS)
+      return "tvOS"
+    #elseif os(watchOS)
+      return "watchOS"
+    #elseif os(OSX)
+      return "macOS"
+    #else
+      return "Unknown"
+    #endif
+  }
+
+  static var osInfo: String {
+    let version = NSProcessInfo.processInfo().operatingSystemVersion
+    return "\(osName) \(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+  }
 }

--- a/Sources/Request/Header.swift
+++ b/Sources/Request/Header.swift
@@ -18,7 +18,7 @@ struct Header {
       let executable: AnyObject = info[kCFBundleExecutableKey as String] ?? "Unknown"
       let bundle: AnyObject = info[kCFBundleIdentifierKey as String] ?? "Unknown"
       let version: AnyObject = info[kCFBundleVersionKey as String] ?? "Unknown"
-      let os: AnyObject = NSProcessInfo.processInfo().operatingSystemVersionString ?? "Unknown"
+      let os: String = Utils.osInfo
       let mutableUserAgent = NSMutableString(
         string: "\(executable)/\(bundle) (\(version); OS \(os))") as CFMutableString
       let transform = NSString(string: "Any-Latin; Latin-ASCII; [:^ASCII:] Remove") as CFString


### PR DESCRIPTION
Since `operatingSystemVersionString` is localized, it is not good to be used in user agent

```
Version 9.1 (Build 13B143)
```

> The operating system version string is human readable, localized, and is appropriate for displaying to the user. This string is not appropriate for parsing

This fixes that by constructing os info, without build number due to lack of official API, so it will be like `iOS 9.1.0`