### PR TITLE
Refactor: multipart form encoding

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		D5EB7C701CB04543003A3BA9 /* MethodRequestableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */; };
 		D5F357CF1D58BDE500153C41 /* MultipartBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */; };
 		D5F357D01D58BDE500153C41 /* MultipartBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */; };
+		D5F357D41D58BE6D00153C41 /* MultipartBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F357D11D58BE6B00153C41 /* MultipartBuilderSpec.swift */; };
+		D5F357D51D58BE6E00153C41 /* MultipartBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F357D11D58BE6B00153C41 /* MultipartBuilderSpec.swift */; };
 		DA5B4CEC1C8E51A0004E21ED /* DataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B4CEB1C8E51A0004E21ED /* DataSerializer.swift */; };
 		DA5B4CED1C8E51A0004E21ED /* DataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B4CEB1C8E51A0004E21ED /* DataSerializer.swift */; };
 		DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B4CEE1C8E5553004E21ED /* StringSerializer.swift */; };
@@ -239,6 +241,7 @@
 		D5EB7C6B1CB03AA0003A3BA9 /* QueryBuilderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryBuilderSpec.swift; sourceTree = "<group>"; };
 		D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodRequestableSpec.swift; sourceTree = "<group>"; };
 		D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartBuilder.swift; sourceTree = "<group>"; };
+		D5F357D11D58BE6B00153C41 /* MultipartBuilderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartBuilderSpec.swift; sourceTree = "<group>"; };
 		DA5B4CEB1C8E51A0004E21ED /* DataSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializer.swift; sourceTree = "<group>"; };
 		DA5B4CEE1C8E5553004E21ED /* StringSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializer.swift; sourceTree = "<group>"; };
 		DA5B4CF71C8E5936004E21ED /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -505,6 +508,7 @@
 				D5B965231C922C1F0099D2F9 /* ETagStorageSpec.swift */,
 				D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */,
 				D5EB7C6B1CB03AA0003A3BA9 /* QueryBuilderSpec.swift */,
+				D5F357D11D58BE6B00153C41 /* MultipartBuilderSpec.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -910,6 +914,7 @@
 				D549C85C1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */,
 				D5B965301C922C420099D2F9 /* WaveValidationSpec.swift in Sources */,
+				D5F357D41D58BE6D00153C41 /* MultipartBuilderSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -993,6 +998,7 @@
 				D549C85D1C8F6C8800588A0C /* StringSerializerSpec.swift in Sources */,
 				D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */,
 				D5B965311C922C420099D2F9 /* WaveValidationSpec.swift in Sources */,
+				D5F357D51D58BE6E00153C41 /* MultipartBuilderSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		D5EB7C6D1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C6B1CB03AA0003A3BA9 /* QueryBuilderSpec.swift */; };
 		D5EB7C6F1CB04543003A3BA9 /* MethodRequestableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */; };
 		D5EB7C701CB04543003A3BA9 /* MethodRequestableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */; };
+		D5F357CF1D58BDE500153C41 /* MultipartBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */; };
+		D5F357D01D58BDE500153C41 /* MultipartBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */; };
 		DA5B4CEC1C8E51A0004E21ED /* DataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B4CEB1C8E51A0004E21ED /* DataSerializer.swift */; };
 		DA5B4CED1C8E51A0004E21ED /* DataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B4CEB1C8E51A0004E21ED /* DataSerializer.swift */; };
 		DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B4CEE1C8E5553004E21ED /* StringSerializer.swift */; };
@@ -236,6 +238,7 @@
 		D5EB7C681CB039DC003A3BA9 /* QueryBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryBuilder.swift; sourceTree = "<group>"; };
 		D5EB7C6B1CB03AA0003A3BA9 /* QueryBuilderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryBuilderSpec.swift; sourceTree = "<group>"; };
 		D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodRequestableSpec.swift; sourceTree = "<group>"; };
+		D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartBuilder.swift; sourceTree = "<group>"; };
 		DA5B4CEB1C8E51A0004E21ED /* DataSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializer.swift; sourceTree = "<group>"; };
 		DA5B4CEE1C8E5553004E21ED /* StringSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializer.swift; sourceTree = "<group>"; };
 		DA5B4CF71C8E5936004E21ED /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -491,6 +494,7 @@
 				D5B965031C9225720099D2F9 /* ETagStorage.swift */,
 				D5B965061C9225B50099D2F9 /* Utils.swift */,
 				D5EB7C681CB039DC003A3BA9 /* QueryBuilder.swift */,
+				D5F357CE1D58BDE500153C41 /* MultipartBuilder.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -853,6 +857,7 @@
 				D5B965201C922BDC0099D2F9 /* WaveValidation.swift in Sources */,
 				DAC92A091C7F961900F01940 /* FormURLEncoder.swift in Sources */,
 				DAC92A061C7F90B400F01940 /* Malibu.swift in Sources */,
+				D5F357CF1D58BDE500153C41 /* MultipartBuilder.swift in Sources */,
 				DA5B4D0A1C8E59A2004E21ED /* Networking.swift in Sources */,
 				DAC92A391C87B95100F01940 /* StatusCodeValidator.swift in Sources */,
 				D5EB7C691CB039DC003A3BA9 /* QueryBuilder.swift in Sources */,
@@ -935,6 +940,7 @@
 				D5B965211C922BDC0099D2F9 /* WaveValidation.swift in Sources */,
 				DAC92A0A1C7F961900F01940 /* FormURLEncoder.swift in Sources */,
 				DAC92A071C7F90B400F01940 /* Malibu.swift in Sources */,
+				D5F357D01D58BDE500153C41 /* MultipartBuilder.swift in Sources */,
 				DA5B4D0B1C8E59A2004E21ED /* Networking.swift in Sources */,
 				DAC92A3A1C87B95100F01940 /* StatusCodeValidator.swift in Sources */,
 				D5EB7C6A1CB039DC003A3BA9 /* QueryBuilder.swift in Sources */,

--- a/MalibuTests/Specs/Encoding/MultipartFormEncoderSpec.swift
+++ b/MalibuTests/Specs/Encoding/MultipartFormEncoderSpec.swift
@@ -15,7 +15,7 @@ class MultipartFormEncoderSpec: QuickSpec {
 
       describe("#encode") {
         it("encodes a dictionary of parameters to NSData object") {
-          let string = encoder.buildMultipartString(parameters, boundary: boundary)
+          let string = encoder.buildMultipartString(parameters)
           let data = string.dataUsingEncoding(NSUTF8StringEncoding,
                                               allowLossyConversion: true)
 
@@ -25,7 +25,6 @@ class MultipartFormEncoderSpec: QuickSpec {
 
       describe("buildMultipartString") {
         it("builds multipart string from parameters and boundary value") {
-          let boundary = "TestBoundary"
           let components = QueryBuilder().buildComponents(parameters: parameters)
           var string = ""
 
@@ -37,7 +36,7 @@ class MultipartFormEncoderSpec: QuickSpec {
 
           string += "--\(boundary)--\r\n"
 
-          expect(encoder.buildMultipartString(parameters, boundary: boundary)).to(equal(string))
+          expect(encoder.buildMultipartString(parameters)).to(equal(string))
         }
       }
     }

--- a/MalibuTests/Specs/Encoding/MultipartFormEncoderSpec.swift
+++ b/MalibuTests/Specs/Encoding/MultipartFormEncoderSpec.swift
@@ -15,28 +15,11 @@ class MultipartFormEncoderSpec: QuickSpec {
 
       describe("#encode") {
         it("encodes a dictionary of parameters to NSData object") {
-          let string = encoder.buildMultipartString(parameters)
+          let string = MultipartBuilder().buildMultipartString(parameters)
           let data = string.dataUsingEncoding(NSUTF8StringEncoding,
                                               allowLossyConversion: true)
 
           expect{ try encoder.encode(parameters) }.to(equal(data))
-        }
-      }
-
-      describe("buildMultipartString") {
-        it("builds multipart string from parameters and boundary value") {
-          let components = QueryBuilder().buildComponents(parameters: parameters)
-          var string = ""
-
-          for (key, value) in components {
-            string += "--\(boundary)\r\n"
-            string += "Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n"
-            string += "\(value)\r\n"
-          }
-
-          string += "--\(boundary)--\r\n"
-
-          expect(encoder.buildMultipartString(parameters)).to(equal(string))
         }
       }
     }

--- a/MalibuTests/Specs/Helpers/MultipartBuilderSpec.swift
+++ b/MalibuTests/Specs/Helpers/MultipartBuilderSpec.swift
@@ -1,0 +1,34 @@
+@testable import Malibu
+import Quick
+import Nimble
+
+class MultipartBuilderSpec: QuickSpec {
+
+  override func spec() {
+    describe("MultipartBuilder") {
+      var builder: MultipartBuilder!
+      let parameters = ["firstname": "John", "lastname": "Hyperseed"]
+
+      beforeEach {
+        builder = MultipartBuilder()
+      }
+
+      describe("buildMultipartString") {
+        it("builds multipart string from parameters and boundary value") {
+          let components = QueryBuilder().buildComponents(parameters: parameters)
+          var string = ""
+
+          for (key, value) in components {
+            string += "--\(boundary)\r\n"
+            string += "Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n"
+            string += "\(value)\r\n"
+          }
+
+          string += "--\(boundary)--\r\n"
+
+          expect(builder.buildMultipartString(parameters)).to(equal(string))
+        }
+      }
+    }
+  }
+}

--- a/Sources/Encoding/MultipartFormEncoder.swift
+++ b/Sources/Encoding/MultipartFormEncoder.swift
@@ -5,29 +5,12 @@ struct MultipartFormEncoder: ParameterEncoding {
   // MARK: - ParameterEncoding
 
   func encode(parameters: [String: AnyObject]) throws -> NSData? {
-    let string = buildMultipartString(parameters)
+    let string = MultipartBuilder().buildMultipartString(parameters)
 
     guard let data = string.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true) else {
       throw Error.InvalidParameter
     }
 
     return data
-  }
-
-  // MARK: - Helpers
-
-  func buildMultipartString(parameters: [String: AnyObject]) -> String {
-    var string = ""
-    let components = QueryBuilder().buildComponents(parameters: parameters)
-
-    for (key, value) in components {
-      string += "--\(boundary)\r\n"
-      string += "Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n"
-      string += "\(value)\r\n"
-    }
-
-    string += "--\(boundary)--\r\n"
-
-    return string
   }
 }

--- a/Sources/Encoding/MultipartFormEncoder.swift
+++ b/Sources/Encoding/MultipartFormEncoder.swift
@@ -5,7 +5,7 @@ struct MultipartFormEncoder: ParameterEncoding {
   // MARK: - ParameterEncoding
 
   func encode(parameters: [String: AnyObject]) throws -> NSData? {
-    let string = buildMultipartString(parameters, boundary: boundary)
+    let string = buildMultipartString(parameters)
 
     guard let data = string.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true) else {
       throw Error.InvalidParameter
@@ -16,7 +16,7 @@ struct MultipartFormEncoder: ParameterEncoding {
 
   // MARK: - Helpers
 
-  func buildMultipartString(parameters: [String: AnyObject], boundary: String) -> String {
+  func buildMultipartString(parameters: [String: AnyObject]) -> String {
     var string = ""
     let components = QueryBuilder().buildComponents(parameters: parameters)
 

--- a/Sources/Helpers/MultipartBuilder.swift
+++ b/Sources/Helpers/MultipartBuilder.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct MultipartBuilder {
+
+  public func buildMultipartString(parameters: [String: AnyObject]) -> String {
+    var string = ""
+    let components = QueryBuilder().buildComponents(parameters: parameters)
+
+    for (key, value) in components {
+      string += "--\(boundary)\r\n"
+      string += "Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n"
+      string += "\(value)\r\n"
+    }
+
+    string += "--\(boundary)--\r\n"
+
+    return string
+  }
+}

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -16,7 +16,7 @@ public var backfootSurfer = Networking()
 public var parameterEncoders = [ContentType: ParameterEncoding]()
 public let logger = Logger()
 
-let boundary = String(format: "Malibu%08x%08x", arc4random(), arc4random())
+public let boundary = String(format: "Malibu%08x%08x", arc4random(), arc4random())
 
 // MARK: - Networkings
 

--- a/Sources/Request/ContentType.swift
+++ b/Sources/Request/ContentType.swift
@@ -34,7 +34,7 @@ public enum ContentType {
       encoder = JSONEncoder()
     case .FormURLEncoded:
       encoder = FormURLEncoder()
-    case .MultipartFormData():
+    case .MultipartFormData:
       encoder = MultipartFormEncoder()
     default:
       break


### PR DESCRIPTION
Move `buildMultipartString` method to a new `MultipartBuilder` struct in order to use it separately.