### PR TITLE
Middleware promise

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -120,17 +120,19 @@ public class Networking: NSObject {
     let ride = Ride()
     let beforePromise = Promise<Void>()
 
-    beforePromise
-      .done({ [weak self] in
-        self?.start(ride, with: request)
-      })
+    let nextRide = beforePromise
       .fail({ error in
         ride.reject(error)
       })
+      .then({
+        return self.start(ride, with: request)
+      })
 
-    middleware(beforePromise)
+    guard let startRide = nextRide as? Ride else {
+      return ride
+    }
 
-    return ride
+    return startRide
   }
 
   // MARK: - Authentication

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -128,6 +128,8 @@ public class Networking: NSObject {
         return self.start(ride, with: request)
       })
 
+    middleware(beforePromise)
+
     guard let startRide = nextRide as? Ride else {
       return ride
     }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -27,7 +27,7 @@ public class Networking: NSObject {
       configuration: self.sessionConfiguration.value,
       delegate: self.sessionDelegate ?? self,
       delegateQueue: nil)
-  }()
+    }()
 
   var requestHeaders: [String: String] {
     var headers = customHeaders
@@ -55,7 +55,8 @@ public class Networking: NSObject {
 
   // MARK: - Networking
 
-  func start(ride: Ride, with request: Requestable) -> Ride {
+  func start(request: Requestable) -> Ride {
+    let ride = Ride()
     let URLRequest: NSMutableURLRequest
 
     do {
@@ -120,21 +121,20 @@ public class Networking: NSObject {
     let ride = Ride()
     let beforePromise = Promise<Void>()
 
-    let nextRide = beforePromise
+    beforePromise
+      .then({
+        return self.start(request)
+      })
+      .done({ wave in
+        ride.resolve(wave)
+      })
       .fail({ error in
         ride.reject(error)
-      })
-      .then({
-        return self.start(ride, with: request)
       })
 
     middleware(beforePromise)
 
-    guard let startRide = nextRide as? Ride else {
-      return ride
-    }
-
-    return startRide
+    return ride
   }
 
   // MARK: - Authentication

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,8 +11,8 @@ public class Networking: NSObject {
   public var beforeEach: (Requestable -> Requestable)?
   public var preProcessRequest: (NSMutableURLRequest -> Void)?
 
-  public var middleware: (() -> Promise<Void>) = {
-    return Promise<Void> { return }
+  public var middleware: (Promise<Void>) -> Void = { promise in
+    promise.resolve()
   }
 
   var baseURLString: URLStringConvertible?
@@ -118,14 +118,17 @@ public class Networking: NSObject {
 
   func execute(request: Requestable) -> Ride {
     let ride = Ride()
+    let beforePromise = Promise<Void>()
 
-    middleware()
+    beforePromise
       .done({ [weak self] in
         self?.start(ride, with: request)
       })
       .fail({ error in
         ride.reject(error)
       })
+
+    middleware(beforePromise)
 
     return ride
   }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -22,7 +22,7 @@ public class Networking: NSObject {
 
   weak var sessionDelegate: NSURLSessionDelegate?
 
-  lazy var session: NSURLSession = {
+  lazy var session: NSURLSession = { [unowned self] in
     return NSURLSession(
       configuration: self.sessionConfiguration.value,
       delegate: self.sessionDelegate ?? self,
@@ -88,8 +88,8 @@ public class Networking: NSObject {
       task = MockDataTask(mock: mock, URLRequest: URLRequest, ride: ride)
     }
 
-    let etagPromise = ride.then { result -> Wave in
-      self.saveEtag(request, response: result.response)
+    let etagPromise = ride.then { [weak self] result -> Wave in
+      self?.saveEtag(request, response: result.response)
       return result
     }
 
@@ -120,8 +120,8 @@ public class Networking: NSObject {
     let ride = Ride()
 
     middleware()
-      .done({ _ in
-        self.start(ride, with: request)
+      .done({ [weak self] in
+        self?.start(ride, with: request)
       })
       .fail({ error in
         ride.reject(error)


### PR DESCRIPTION
"Middleware" is the function which works with the first promise in the chain, before the actual request. It could be used to prepare networking, do some kind of pre-processing task, cancel request under particular conditions, etc.

For example, in the combination with https://github.com/hyperoslo/OhMyAuth

```swift
// In your configuration
// Remember to `resolve` or `reject` the promise
networking.middleware = { promise in
  AuthContainer.serviceNamed("service")?.accessToken { accessToken, error in
    if let error == error {
      promise.reject(error)
      return
    }

    guard let accessToken = accessToken else {
      promise.reject(CustomError())
      return
    }

    self.networking.authenticate(bearerToken: accessToken)
    promise.resolve()
  }
}

// Send your request like you usually do
networking.GET(request)
  .validate()
  .toJSONDictionary()
```