### PR TITLE
Feature: offline cache of requests

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -15,8 +15,6 @@
 		D503D3A61C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
 		D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
 		D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
-		D5339AF31D9C697F00E8A7AD /* OfflineStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */; };
-		D5339AF41D9C697F00E8A7AD /* OfflineStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */; };
 		D53FBEAA1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D53FBEAB1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
@@ -190,7 +188,6 @@
 		D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
 		D527ED981C9B84A20092AD6B /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
-		D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfflineStorage.swift; sourceTree = "<group>"; };
 		D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperationSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
@@ -348,14 +345,6 @@
 			path = Serialization;
 			sourceTree = "<group>";
 		};
-		D55327CE1D9C688B003011D5 /* Offline */ = {
-			isa = PBXGroup;
-			children = (
-				D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */,
-			);
-			path = Offline;
-			sourceTree = "<group>";
-		};
 		D559C5E01CC018FA00700B3C /* JSON */ = {
 			isa = PBXGroup;
 			children = (
@@ -492,7 +481,6 @@
 				DA5B4D031C8E59A2004E21ED /* Networking.swift */,
 				DAEE2BAC1C7F8A770000FB12 /* Encoding */,
 				D5D3898E1C88DF900039967A /* Helpers */,
-				D55327CE1D9C688B003011D5 /* Offline */,
 				D5779BBA1D98473B00123D98 /* Operation */,
 				D5B964F01C92119D0099D2F9 /* Request */,
 				D5B965151C922BDC0099D2F9 /* Response */,
@@ -872,7 +860,6 @@
 				D5EB7C691CB039DC003A3BA9 /* QueryBuilder.swift in Sources */,
 				D5779BCB1D991D4B00123D98 /* ResponseHandler.swift in Sources */,
 				DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */,
-				D5339AF31D9C697F00E8A7AD /* OfflineStorage.swift in Sources */,
 				D5B964F21C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651E1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
 				D5EB7C601CB01E73003A3BA9 /* RequestPolicies.swift in Sources */,
@@ -959,7 +946,6 @@
 				D5EB7C6A1CB039DC003A3BA9 /* QueryBuilder.swift in Sources */,
 				D5779BCC1D991D4B00123D98 /* ResponseHandler.swift in Sources */,
 				DA5B4CF01C8E5553004E21ED /* StringSerializer.swift in Sources */,
-				D5339AF41D9C697F00E8A7AD /* OfflineStorage.swift in Sources */,
 				D5B964F31C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651F1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
 				D5EB7C611CB01E73003A3BA9 /* RequestPolicies.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		D503D3A61C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
 		D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
 		D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
+		D5339AF61D9C6C5900E8A7AD /* RequestStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */; };
+		D5339AF71D9C6C5900E8A7AD /* RequestStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */; };
 		D53FBEAA1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D53FBEAB1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
@@ -188,6 +190,7 @@
 		D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
 		D527ED981C9B84A20092AD6B /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
+		D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestStorage.swift; sourceTree = "<group>"; };
 		D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperationSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
@@ -418,6 +421,7 @@
 				D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */,
 				D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */,
 				D5C1D06E1CB3D49F00A076D6 /* Ride.swift */,
+				D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -834,6 +838,7 @@
 				D5779BC81D991CA400123D98 /* MockOperation.swift in Sources */,
 				DA5B4CEC1C8E51A0004E21ED /* DataSerializer.swift in Sources */,
 				DAC92A3C1C87C00C00F01940 /* ContentTypeValidator.swift in Sources */,
+				D5339AF61D9C6C5900E8A7AD /* RequestStorage.swift in Sources */,
 				D503D3901C8DA95B0009BDAD /* JSONSerializer.swift in Sources */,
 				D5B965071C9225B50099D2F9 /* Utils.swift in Sources */,
 				DAEE2BB11C7F8BA00000FB12 /* JSONEncoder.swift in Sources */,
@@ -920,6 +925,7 @@
 				D5779BC91D991CA400123D98 /* MockOperation.swift in Sources */,
 				DA5B4CED1C8E51A0004E21ED /* DataSerializer.swift in Sources */,
 				DAC92A3D1C87C00C00F01940 /* ContentTypeValidator.swift in Sources */,
+				D5339AF71D9C6C5900E8A7AD /* RequestStorage.swift in Sources */,
 				D503D3911C8DA95B0009BDAD /* JSONSerializer.swift in Sources */,
 				D5B965081C9225B50099D2F9 /* Utils.swift in Sources */,
 				DAEE2BB21C7F8BA00000FB12 /* JSONEncoder.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		D503D3A61C8EC7550009BDAD /* NetworkPromiseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */; };
 		D527ED991C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
 		D527ED9A1C9B84A20092AD6B /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527ED981C9B84A20092AD6B /* MethodSpec.swift */; };
+		D5339AF31D9C697F00E8A7AD /* OfflineStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */; };
+		D5339AF41D9C697F00E8A7AD /* OfflineStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */; };
 		D53FBEAA1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D53FBEAB1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D549C8561C8F661E00588A0C /* JSONSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */; };
@@ -111,8 +113,8 @@
 		D5E061D91D06E5EF009740F2 /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E061D61D06E5AD009740F2 /* When.framework */; };
 		D5E061DC1D06E5EF009740F2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E061DA1D06E5EF009740F2 /* Quick.framework */; };
 		D5E061DD1D06E5EF009740F2 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E061DB1D06E5EF009740F2 /* Nimble.framework */; };
-		D5EB7C601CB01E73003A3BA9 /* ETagPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C5F1CB01E73003A3BA9 /* ETagPolicy.swift */; };
-		D5EB7C611CB01E73003A3BA9 /* ETagPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C5F1CB01E73003A3BA9 /* ETagPolicy.swift */; };
+		D5EB7C601CB01E73003A3BA9 /* RequestPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */; };
+		D5EB7C611CB01E73003A3BA9 /* RequestPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */; };
 		D5EB7C631CB02323003A3BA9 /* MethodRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */; };
 		D5EB7C641CB02323003A3BA9 /* MethodRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */; };
 		D5EB7C691CB039DC003A3BA9 /* QueryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C681CB039DC003A3BA9 /* QueryBuilder.swift */; };
@@ -188,6 +190,7 @@
 		D503D38F1C8DA95B0009BDAD /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
 		D527ED981C9B84A20092AD6B /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
+		D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfflineStorage.swift; sourceTree = "<group>"; };
 		D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperationSpec.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JSONSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
@@ -245,7 +248,7 @@
 		D5E061D61D06E5AD009740F2 /* When.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = When.framework; path = Carthage/Build/Mac/When.framework; sourceTree = "<group>"; };
 		D5E061DA1D06E5EF009740F2 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
 		D5E061DB1D06E5EF009740F2 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
-		D5EB7C5F1CB01E73003A3BA9 /* ETagPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETagPolicy.swift; sourceTree = "<group>"; };
+		D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPolicies.swift; sourceTree = "<group>"; };
 		D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodRequestable.swift; sourceTree = "<group>"; };
 		D5EB7C681CB039DC003A3BA9 /* QueryBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryBuilder.swift; sourceTree = "<group>"; };
 		D5EB7C6B1CB03AA0003A3BA9 /* QueryBuilderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryBuilderSpec.swift; sourceTree = "<group>"; };
@@ -345,6 +348,14 @@
 			path = Serialization;
 			sourceTree = "<group>";
 		};
+		D55327CE1D9C688B003011D5 /* Offline */ = {
+			isa = PBXGroup;
+			children = (
+				D5339AF21D9C697F00E8A7AD /* OfflineStorage.swift */,
+			);
+			path = Offline;
+			sourceTree = "<group>";
+		};
 		D559C5E01CC018FA00700B3C /* JSON */ = {
 			isa = PBXGroup;
 			children = (
@@ -416,7 +427,7 @@
 				D5B964F11C9211AF0099D2F9 /* Message.swift */,
 				D5B964F41C92125E0099D2F9 /* Requestable.swift */,
 				D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */,
-				D5EB7C5F1CB01E73003A3BA9 /* ETagPolicy.swift */,
+				D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */,
 				D5C1D06E1CB3D49F00A076D6 /* Ride.swift */,
 			);
 			path = Request;
@@ -481,6 +492,7 @@
 				DA5B4D031C8E59A2004E21ED /* Networking.swift */,
 				DAEE2BAC1C7F8A770000FB12 /* Encoding */,
 				D5D3898E1C88DF900039967A /* Helpers */,
+				D55327CE1D9C688B003011D5 /* Offline */,
 				D5779BBA1D98473B00123D98 /* Operation */,
 				D5B964F01C92119D0099D2F9 /* Request */,
 				D5B965151C922BDC0099D2F9 /* Response */,
@@ -860,9 +872,10 @@
 				D5EB7C691CB039DC003A3BA9 /* QueryBuilder.swift in Sources */,
 				D5779BCB1D991D4B00123D98 /* ResponseHandler.swift in Sources */,
 				DA5B4CEF1C8E5553004E21ED /* StringSerializer.swift in Sources */,
+				D5339AF31D9C697F00E8A7AD /* OfflineStorage.swift in Sources */,
 				D5B964F21C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651E1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
-				D5EB7C601CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
+				D5EB7C601CB01E73003A3BA9 /* RequestPolicies.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* Error.swift in Sources */,
 				D5A3DC881CD164750084F451 /* Logging.swift in Sources */,
 				D5B9650D1C922BCF0099D2F9 /* ContentType.swift in Sources */,
@@ -946,9 +959,10 @@
 				D5EB7C6A1CB039DC003A3BA9 /* QueryBuilder.swift in Sources */,
 				D5779BCC1D991D4B00123D98 /* ResponseHandler.swift in Sources */,
 				DA5B4CF01C8E5553004E21ED /* StringSerializer.swift in Sources */,
+				D5339AF41D9C697F00E8A7AD /* OfflineStorage.swift in Sources */,
 				D5B964F31C9211AF0099D2F9 /* Message.swift in Sources */,
 				D5B9651F1C922BDC0099D2F9 /* WaveSerialization.swift in Sources */,
-				D5EB7C611CB01E73003A3BA9 /* ETagPolicy.swift in Sources */,
+				D5EB7C611CB01E73003A3BA9 /* RequestPolicies.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* Error.swift in Sources */,
 				D5A3DC891CD164750084F451 /* Logging.swift in Sources */,
 				D5B9650E1C922BCF0099D2F9 /* ContentType.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		D5779BD61D99206200123D98 /* MockOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5779BD41D99206200123D98 /* MockOperationSpec.swift */; };
 		D5779BD81D99210400123D98 /* DataOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5779BD71D99210400123D98 /* DataOperationSpec.swift */; };
 		D5779BD91D99210400123D98 /* DataOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5779BD71D99210400123D98 /* DataOperationSpec.swift */; };
+		D598662F1D9DA42C00D4D90F /* RequestStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D598662E1D9DA42C00D4D90F /* RequestStorageSpec.swift */; };
+		D59866301D9DA42C00D4D90F /* RequestStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D598662E1D9DA42C00D4D90F /* RequestStorageSpec.swift */; };
 		D5A3DC881CD164750084F451 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A3DC871CD164750084F451 /* Logging.swift */; };
 		D5A3DC891CD164750084F451 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A3DC871CD164750084F451 /* Logging.swift */; };
 		D5ABDDAA1CD78BC700C78B5F /* MultipartFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5ABDDA91CD78BC700C78B5F /* MultipartFormEncoder.swift */; };
@@ -211,6 +213,7 @@
 		D5779BD11D99203E00123D98 /* MockSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSpec.swift; sourceTree = "<group>"; };
 		D5779BD41D99206200123D98 /* MockOperationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOperationSpec.swift; sourceTree = "<group>"; };
 		D5779BD71D99210400123D98 /* DataOperationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataOperationSpec.swift; sourceTree = "<group>"; };
+		D598662E1D9DA42C00D4D90F /* RequestStorageSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestStorageSpec.swift; sourceTree = "<group>"; };
 		D5A3DC871CD164750084F451 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		D5ABDDA91CD78BC700C78B5F /* MultipartFormEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormEncoder.swift; sourceTree = "<group>"; };
 		D5ABDDAC1CD8132700C78B5F /* MultipartFormEncoderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormEncoderSpec.swift; sourceTree = "<group>"; };
@@ -445,6 +448,7 @@
 				D5B964FB1C9217140099D2F9 /* RequestableSpec.swift */,
 				D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */,
 				D5C000C11D9D9D3E00744A12 /* RequestCapsuleSpec.swift */,
+				D598662E1D9DA42C00D4D90F /* RequestStorageSpec.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -897,6 +901,7 @@
 				D5B965371C922C500099D2F9 /* SessionConfigurationSpec.swift in Sources */,
 				D5B965391C922C500099D2F9 /* URLStringConvertibleSpec.swift in Sources */,
 				D5B9652A1C922C420099D2F9 /* MIMETypeSpec.swift in Sources */,
+				D598662F1D9DA42C00D4D90F /* RequestStorageSpec.swift in Sources */,
 				D5B964F91C9216FD0099D2F9 /* MessageSpec.swift in Sources */,
 				D5B9653C1C92340C0099D2F9 /* UtilsSpec.swift in Sources */,
 				DAEE2BB71C7F8C5D0000FB12 /* JSONEncoderSpec.swift in Sources */,
@@ -986,6 +991,7 @@
 				D5B965381C922C500099D2F9 /* SessionConfigurationSpec.swift in Sources */,
 				D5B9653A1C922C500099D2F9 /* URLStringConvertibleSpec.swift in Sources */,
 				D5B9652B1C922C420099D2F9 /* MIMETypeSpec.swift in Sources */,
+				D59866301D9DA42C00D4D90F /* RequestStorageSpec.swift in Sources */,
 				D5B964FA1C9216FD0099D2F9 /* MessageSpec.swift in Sources */,
 				D5B9653D1C92340C0099D2F9 /* UtilsSpec.swift in Sources */,
 				DAEE2BB81C7F8C5E0000FB12 /* JSONEncoderSpec.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -113,6 +113,8 @@
 		D5E061D91D06E5EF009740F2 /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E061D61D06E5AD009740F2 /* When.framework */; };
 		D5E061DC1D06E5EF009740F2 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E061DA1D06E5EF009740F2 /* Quick.framework */; };
 		D5E061DD1D06E5EF009740F2 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E061DB1D06E5EF009740F2 /* Nimble.framework */; };
+		D5E8EDC31D9D865B0087690A /* RequestCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E8EDC21D9D865B0087690A /* RequestCapsule.swift */; };
+		D5E8EDC41D9D865B0087690A /* RequestCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E8EDC21D9D865B0087690A /* RequestCapsule.swift */; };
 		D5EB7C601CB01E73003A3BA9 /* RequestPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */; };
 		D5EB7C611CB01E73003A3BA9 /* RequestPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */; };
 		D5EB7C631CB02323003A3BA9 /* MethodRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */; };
@@ -248,6 +250,7 @@
 		D5E061D61D06E5AD009740F2 /* When.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = When.framework; path = Carthage/Build/Mac/When.framework; sourceTree = "<group>"; };
 		D5E061DA1D06E5EF009740F2 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
 		D5E061DB1D06E5EF009740F2 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
+		D5E8EDC21D9D865B0087690A /* RequestCapsule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestCapsule.swift; sourceTree = "<group>"; };
 		D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPolicies.swift; sourceTree = "<group>"; };
 		D5EB7C621CB02323003A3BA9 /* MethodRequestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodRequestable.swift; sourceTree = "<group>"; };
 		D5EB7C681CB039DC003A3BA9 /* QueryBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryBuilder.swift; sourceTree = "<group>"; };
@@ -422,6 +425,7 @@
 				D5EB7C5F1CB01E73003A3BA9 /* RequestPolicies.swift */,
 				D5C1D06E1CB3D49F00A076D6 /* Ride.swift */,
 				D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */,
+				D5E8EDC21D9D865B0087690A /* RequestCapsule.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -841,6 +845,7 @@
 				D5339AF61D9C6C5900E8A7AD /* RequestStorage.swift in Sources */,
 				D503D3901C8DA95B0009BDAD /* JSONSerializer.swift in Sources */,
 				D5B965071C9225B50099D2F9 /* Utils.swift in Sources */,
+				D5E8EDC31D9D865B0087690A /* RequestCapsule.swift in Sources */,
 				DAEE2BB11C7F8BA00000FB12 /* JSONEncoder.swift in Sources */,
 				DAC92A361C87B92200F01940 /* Validating.swift in Sources */,
 				DAEE2BAE1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,
@@ -928,6 +933,7 @@
 				D5339AF71D9C6C5900E8A7AD /* RequestStorage.swift in Sources */,
 				D503D3911C8DA95B0009BDAD /* JSONSerializer.swift in Sources */,
 				D5B965081C9225B50099D2F9 /* Utils.swift in Sources */,
+				D5E8EDC41D9D865B0087690A /* RequestCapsule.swift in Sources */,
 				DAEE2BB21C7F8BA00000FB12 /* JSONEncoder.swift in Sources */,
 				DAC92A371C87B92200F01940 /* Validating.swift in Sources */,
 				DAEE2BAF1C7F8A870000FB12 /* ParameterEncoding.swift in Sources */,

--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		D5B9653A1C922C500099D2F9 /* URLStringConvertibleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */; };
 		D5B9653C1C92340C0099D2F9 /* UtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */; };
 		D5B9653D1C92340C0099D2F9 /* UtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */; };
+		D5C000C21D9D9D3E00744A12 /* RequestCapsuleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C000C11D9D9D3E00744A12 /* RequestCapsuleSpec.swift */; };
+		D5C000C31D9D9D3E00744A12 /* RequestCapsuleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C000C11D9D9D3E00744A12 /* RequestCapsuleSpec.swift */; };
 		D5C1D06F1CB3D49F00A076D6 /* Ride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C1D06E1CB3D49F00A076D6 /* Ride.swift */; };
 		D5C1D0701CB3D49F00A076D6 /* Ride.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C1D06E1CB3D49F00A076D6 /* Ride.swift */; };
 		D5C6294A1C3A7FAA007F7B7C /* Malibu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Malibu.framework */; };
@@ -238,6 +240,7 @@
 		D5B965331C922C500099D2F9 /* SessionConfigurationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionConfigurationSpec.swift; sourceTree = "<group>"; };
 		D5B965341C922C500099D2F9 /* URLStringConvertibleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLStringConvertibleSpec.swift; sourceTree = "<group>"; };
 		D5B9653B1C92340C0099D2F9 /* UtilsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilsSpec.swift; sourceTree = "<group>"; };
+		D5C000C11D9D9D3E00744A12 /* RequestCapsuleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestCapsuleSpec.swift; sourceTree = "<group>"; };
 		D5C1D06E1CB3D49F00A076D6 /* Ride.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ride.swift; sourceTree = "<group>"; };
 		D5C629401C3A7FAA007F7B7C /* Malibu.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Malibu.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C629491C3A7FAA007F7B7C /* Malibu-Mac-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Malibu-Mac-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -441,6 +444,7 @@
 				D5B964F81C9216FD0099D2F9 /* MessageSpec.swift */,
 				D5B964FB1C9217140099D2F9 /* RequestableSpec.swift */,
 				D5EB7C6E1CB04543003A3BA9 /* MethodRequestableSpec.swift */,
+				D5C000C11D9D9D3E00744A12 /* RequestCapsuleSpec.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -912,6 +916,7 @@
 				D560A2E41C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */,
 				D5B965351C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
 				D5EB7C6C1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */,
+				D5C000C21D9D9D3E00744A12 /* RequestCapsuleSpec.swift in Sources */,
 				D53FBEAA1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */,
 				D5ABDDAF1CD8149500C78B5F /* MultipartFormEncoderSpec.swift in Sources */,
 				D5B9652E1C922C420099D2F9 /* WaveSpec.swift in Sources */,
@@ -1000,6 +1005,7 @@
 				D560A2E51C8C66EC00D4B640 /* StatusCodeVadatorSpec.swift in Sources */,
 				D5B965361C922C500099D2F9 /* ContentTypeSpec.swift in Sources */,
 				D5EB7C6D1CB03AA0003A3BA9 /* QueryBuilderSpec.swift in Sources */,
+				D5C000C31D9D9D3E00744A12 /* RequestCapsuleSpec.swift in Sources */,
 				D53FBEAB1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */,
 				D5ABDDB01CD8149600C78B5F /* MultipartFormEncoderSpec.swift in Sources */,
 				D5B9652F1C922C420099D2F9 /* WaveSpec.swift in Sources */,

--- a/MalibuTests/Specs/ErrorSpec.swift
+++ b/MalibuTests/Specs/ErrorSpec.swift
@@ -71,6 +71,24 @@ class ErrorSpec: QuickSpec {
           }
         }
       }
+
+      context("when it's offline error") {
+        var offlineError: NSError!
+
+        beforeEach {
+          offlineError = NSError(
+            domain: "no.hyper.Malibu",
+            code: Int(CFNetworkErrors.CFURLErrorNotConnectedToInternet.rawValue),
+            userInfo: nil
+          )
+        }
+
+        describe("#reason") {
+          it("returns true") {
+            expect(offlineError.isOffline).to(beTrue())
+          }
+        }
+      }
     }
   }
 }

--- a/MalibuTests/Specs/MalibuSpec.swift
+++ b/MalibuTests/Specs/MalibuSpec.swift
@@ -24,6 +24,7 @@ class MalibuSpec: QuickSpec {
         it("adds new networking instance with a name") {
           expect(Malibu.networkings.count).to(equal(1))
           expect(Malibu.networkings["surfer"]?.baseURLString?.URLString).to(equal(baseURLString.URLString))
+          expect(Malibu.networkings["surfer"]?.requestStorage.name).to(equal("surfer"))
         }
       }
 

--- a/MalibuTests/Specs/MalibuSpec.swift
+++ b/MalibuTests/Specs/MalibuSpec.swift
@@ -24,7 +24,7 @@ class MalibuSpec: QuickSpec {
         it("adds new networking instance with a name") {
           expect(Malibu.networkings.count).to(equal(1))
           expect(Malibu.networkings["surfer"]?.baseURLString?.URLString).to(equal(baseURLString.URLString))
-          expect(Malibu.networkings["surfer"]?.requestStorage.name).to(equal("surfer"))
+          expect(Malibu.networkings["surfer"]?.requestStorage.key).to(equal("\(RequestStorage.domain).surfer"))
         }
       }
 

--- a/MalibuTests/Specs/Request/ContentTypeSpec.swift
+++ b/MalibuTests/Specs/Request/ContentTypeSpec.swift
@@ -13,7 +13,7 @@ class ContentTypeSpec: QuickSpec {
           contentType = .Query
         }
 
-        describe("init:header") {
+        describe("#init:header") {
           let result = ContentType(header: nil)
           expect(result).to(equal(ContentType.Query))
         }
@@ -50,7 +50,7 @@ class ContentTypeSpec: QuickSpec {
           contentType = .FormURLEncoded
         }
 
-        describe("init:header") {
+        describe("#init:header") {
           let result = ContentType(header: "application/x-www-form-urlencoded")
           expect(result).to(equal(ContentType.FormURLEncoded))
         }
@@ -87,7 +87,7 @@ class ContentTypeSpec: QuickSpec {
           contentType = .JSON
         }
 
-        describe("init:header") {
+        describe("#init:header") {
           let result = ContentType(header: "application/json")
           expect(result).to(equal(ContentType.JSON))
         }
@@ -124,7 +124,7 @@ class ContentTypeSpec: QuickSpec {
           contentType = .MultipartFormData
         }
 
-        describe("init:header") {
+        describe("#init:header") {
           let result = ContentType(header: "multipart/form-data; boundary=\(boundary)")
           expect(result).to(equal(ContentType.MultipartFormData))
         }
@@ -162,7 +162,7 @@ class ContentTypeSpec: QuickSpec {
           contentType = .Custom("application/custom")
         }
 
-        describe("init:header") {
+        describe("#init:header") {
           let result = ContentType(header: "application/custom")
           expect(result).to(equal(ContentType.Custom("application/custom")))
         }

--- a/MalibuTests/Specs/Request/ContentTypeSpec.swift
+++ b/MalibuTests/Specs/Request/ContentTypeSpec.swift
@@ -13,6 +13,11 @@ class ContentTypeSpec: QuickSpec {
           contentType = .Query
         }
 
+        describe("init:header") {
+          let result = ContentType(header: nil)
+          expect(result).to(equal(ContentType.Query))
+        }
+
         describe("#value") {
           it("returns nil") {
             expect(contentType.header).to(beNil())
@@ -43,6 +48,11 @@ class ContentTypeSpec: QuickSpec {
       context("when it is FormURLEncoded type") {
         beforeEach {
           contentType = .FormURLEncoded
+        }
+
+        describe("init:header") {
+          let result = ContentType(header: "application/x-www-form-urlencoded")
+          expect(result).to(equal(ContentType.FormURLEncoded))
         }
 
         describe("#value") {
@@ -77,6 +87,11 @@ class ContentTypeSpec: QuickSpec {
           contentType = .JSON
         }
 
+        describe("init:header") {
+          let result = ContentType(header: "application/json")
+          expect(result).to(equal(ContentType.JSON))
+        }
+
         describe("#value") {
           it("returns a correct string value") {
             expect(contentType.header).to(equal("application/json"))
@@ -107,6 +122,11 @@ class ContentTypeSpec: QuickSpec {
       context("when it is MultipartFormData type") {
         beforeEach {
           contentType = .MultipartFormData
+        }
+
+        describe("init:header") {
+          let result = ContentType(header: "multipart/form-data; boundary=\(boundary)")
+          expect(result).to(equal(ContentType.MultipartFormData))
         }
 
         describe("#value") {
@@ -140,6 +160,11 @@ class ContentTypeSpec: QuickSpec {
       context("when it is Custom type") {
         beforeEach {
           contentType = .Custom("application/custom")
+        }
+
+        describe("init:header") {
+          let result = ContentType(header: "application/custom")
+          expect(result).to(equal(ContentType.Custom("application/custom")))
         }
 
         describe("#value") {

--- a/MalibuTests/Specs/Request/RequestCapsuleSpec.swift
+++ b/MalibuTests/Specs/Request/RequestCapsuleSpec.swift
@@ -1,0 +1,43 @@
+@testable import Malibu
+import Quick
+import Nimble
+
+class RequestCapsuleSpec: QuickSpec {
+
+  override func spec() {
+    describe("RequestCapsule") {
+      var request: Requestable!
+      var capsule: RequestCapsule!
+
+      beforeEach {
+        request = GETRequest()
+        capsule = RequestCapsule(request: request)
+      }
+
+      describe("#init") {
+        it("sets values") {
+          expect(capsule.method).to(equal(request.method))
+          expect(capsule.message).to(equal(request.message))
+          expect(capsule.contentType).to(equal(request.contentType))
+          expect(capsule.etagPolicy).to(equal(request.etagPolicy))
+          expect(capsule.storePolicy).to(equal(request.storePolicy))
+          expect(capsule.cachePolicy).to(equal(request.cachePolicy))
+        }
+      }
+
+      describe("#init:coder") {
+        it("creates an instance") {
+          let data = NSKeyedArchiver.archivedDataWithRootObject(capsule)
+          let result = NSKeyedUnarchiver.unarchiveObjectWithData(data) as! RequestCapsule
+
+          expect(result.method).to(equal(capsule.method))
+          expect(result.message).to(equal(capsule.message))
+          expect(result.contentType).to(equal(capsule.contentType))
+          expect(result.etagPolicy).to(equal(capsule.etagPolicy))
+          expect(result.storePolicy).to(equal(capsule.storePolicy))
+          expect(result.cachePolicy).to(equal(capsule.cachePolicy))
+        }
+      }
+    }
+  }
+}

--- a/MalibuTests/Specs/Request/RequestCapsuleSpec.swift
+++ b/MalibuTests/Specs/Request/RequestCapsuleSpec.swift
@@ -22,6 +22,7 @@ class RequestCapsuleSpec: QuickSpec {
           expect(capsule.etagPolicy).to(equal(request.etagPolicy))
           expect(capsule.storePolicy).to(equal(request.storePolicy))
           expect(capsule.cachePolicy).to(equal(request.cachePolicy))
+          expect(capsule.id).to(equal(request.message.resource.URLString))
         }
       }
 

--- a/MalibuTests/Specs/Request/RequestStorageSpec.swift
+++ b/MalibuTests/Specs/Request/RequestStorageSpec.swift
@@ -1,0 +1,123 @@
+@testable import Malibu
+import Quick
+import Nimble
+
+class RequestStorageSpec: QuickSpec {
+
+  override func spec() {
+    describe("RequestStorage") {
+      let name = "Test"
+      var storage: RequestStorage!
+
+      beforeEach {
+        storage = RequestStorage(name: name)
+      }
+
+      afterEach {
+        storage.clear()
+      }
+
+      describe("#init") {
+        it("sets values") {
+          expect(storage.key).to(equal("\(RequestStorage.domain).\(name)"))
+        }
+      }
+
+      describe("#save") {
+        it("saves a capsule") {
+          let capsule = RequestCapsule(request: GETRequest())
+          storage.save(capsule)
+
+          expect(storage.requests.count).to(equal(1))
+          expect(storage.requests[capsule.id]).toNot(beNil())
+          expect(storage.load().count).to(equal(1))
+          expect(storage.load()[capsule.id]).toNot(beNil())
+        }
+      }
+
+      describe("#saveAll") {
+        it("saves all capsules") {
+          let capsule1 = RequestCapsule(request: GETRequest())
+          let capsule2 = RequestCapsule(request: POSTRequest())
+          storage.requests["id1"] = capsule1
+          storage.requests["id2"] = capsule2
+
+          storage.saveAll()
+
+          expect(storage.requests.count).to(equal(2))
+          expect(storage.load().count).to(equal(2))
+        }
+      }
+
+      describe("#remove") {
+        it("removes a capsule") {
+          let capsule = RequestCapsule(request: GETRequest())
+          storage.save(capsule)
+
+          expect(storage.requests.count).to(equal(1))
+          expect(storage.load().count).to(equal(1))
+
+          storage.remove(capsule)
+
+          expect(storage.requests.count).to(equal(0))
+          expect(storage.load().count).to(equal(0))
+        }
+      }
+
+      describe("#clear") {
+        it("removes all capsules") {
+          let capsule = RequestCapsule(request: GETRequest())
+          storage.save(capsule)
+
+          expect(storage.requests.count).to(equal(1))
+          expect(storage.load().count).to(equal(1))
+
+          storage.clear()
+
+          expect(storage.requests.count).to(equal(0))
+          expect(storage.load().count).to(equal(0))
+        }
+      }
+
+      describe("#clearAll") {
+        it("removes all capsules from every storage") {
+          var storage2 = RequestStorage()
+          let capsule = RequestCapsule(request: GETRequest())
+
+          storage.save(capsule)
+          storage2.save(capsule)
+
+          expect(storage.requests.count).to(equal(1))
+          expect(storage.load().count).to(equal(1))
+          expect(storage2.requests.count).to(equal(1))
+          expect(storage2.load().count).to(equal(1))
+
+          RequestStorage.clearAll()
+
+          storage = RequestStorage(name: name)
+          storage2 = RequestStorage()
+
+          expect(storage.requests.count).to(equal(0))
+          expect(storage.load().count).to(equal(0))
+          expect(storage2.requests.count).to(equal(0))
+          expect(storage2.load().count).to(equal(0))
+        }
+      }
+
+      describe("#load") {
+        it("loads capsules") {
+          let capsule = RequestCapsule(request: GETRequest())
+          storage.save(capsule)
+
+          expect(storage.requests.count).to(equal(1))
+          expect(storage.load().count).to(equal(1))
+
+          storage = RequestStorage(name: name)
+
+          expect(storage.requests.count).to(equal(1))
+          expect(storage.load().count).to(equal(1))
+        }
+      }
+    }
+  }
+}

--- a/MalibuTests/Specs/Request/RequestableSpec.swift
+++ b/MalibuTests/Specs/Request/RequestableSpec.swift
@@ -20,6 +20,12 @@ class RequestableSpec: QuickSpec {
         } catch {}
       }
 
+      describe("#storePolicy") {
+        it("has default value") {
+          expect(request.storePolicy).to(equal(StorePolicy.Unspecified))
+        }
+      }
+
       describe("#cachePolicy") {
         it("has default value") {
           expect(request.cachePolicy).to(equal(NSURLRequestCachePolicy.UseProtocolCachePolicy))

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -62,3 +62,12 @@ extension Error: Hashable {
 public func ==(lhs: Error, rhs: Error) -> Bool {
   return lhs.reason == rhs.reason
 }
+
+// MARK: - NSError
+
+extension NSError {
+
+  var isOffline: Bool {
+    return Int32(code) == CFNetworkErrors.CFURLErrorNotConnectedToInternet.rawValue
+  }
+}

--- a/Sources/Malibu.swift
+++ b/Sources/Malibu.swift
@@ -21,15 +21,29 @@ public let boundary = String(format: "Malibu%08x%08x", arc4random(), arc4random(
 // MARK: - Networkings
 
 public func register(name: String, networking: Networking) {
+  networking.requestStorage = RequestStorage(name: name)
   networkings[name] = networking
 }
 
 public func unregister(name: String) -> Bool {
-  return networkings.removeValueForKey(name) != nil
+  guard let networking = networkings.removeValueForKey(name) else {
+    return false
+  }
+
+  networking.requestStorage.clear()
+
+  return true
 }
 
 public func networking(name: String) -> Networking {
   return networkings[name] ?? backfootSurfer
+}
+
+// MARK: - Storages
+
+public func clearStorages() {
+  ETagStorage().clear()
+  RequestStorage.clearAll()
 }
 
 // MARK: - Mocks

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -201,7 +201,7 @@ public class Networking: NSObject {
   }
 
   func handleError(error: ErrorType, request: Requestable, URLRequest: NSURLRequest) {
-    guard request.storePolicy == StorePolicy.Offline && (error as NSError).isOffline == true else {
+    guard request.storePolicy == StorePolicy.Offline && (error as NSError).isOffline else {
       return
     }
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -201,9 +201,11 @@ public class Networking: NSObject {
   }
 
   func handleError(error: ErrorType, request: Requestable, URLRequest: NSURLRequest) {
-    if request.storePolicy == StorePolicy.Offline && (error as NSError).isOffline == true {
-      self.requestStorage.save(URLRequest)
+    guard request.storePolicy == StorePolicy.Offline && (error as NSError).isOffline == true else {
+      return
     }
+
+    requestStorage.save(URLRequest)
   }
 }
 

--- a/Sources/Request/ContentType.swift
+++ b/Sources/Request/ContentType.swift
@@ -46,7 +46,7 @@ public enum ContentType {
     case .FormURLEncoded:
       string = Header.FormURLEncoded.rawValue
     case .MultipartFormData:
-      string = Header.MultipartFormData.rawValue
+      string = "\(Header.MultipartFormData.rawValue)\(boundary)"
     case .Custom(let value):
       string = value
     }

--- a/Sources/Request/ContentType.swift
+++ b/Sources/Request/ContentType.swift
@@ -7,6 +7,34 @@ public enum ContentType {
   case MultipartFormData
   case Custom(String)
 
+  enum Header: String {
+    case JSON = "application/json"
+    case FormURLEncoded = "application/x-www-form-urlencoded"
+    case MultipartFormData = "multipart/form-data; boundary="
+  }
+
+  init(header: String?) {
+    guard let header = header else {
+      self = .Query
+      return
+    }
+
+    let result: ContentType
+
+    switch header {
+    case Header.JSON.rawValue:
+      result = .JSON
+    case Header.FormURLEncoded.rawValue:
+      result = .FormURLEncoded
+    case "\(Header.MultipartFormData.rawValue)\(boundary)":
+      result = .MultipartFormData
+    default:
+      result = .Custom(header)
+    }
+
+    self = result
+  }
+
   var header: String? {
     let string: String?
 
@@ -14,11 +42,11 @@ public enum ContentType {
     case .Query:
       string = nil
     case .JSON:
-      string = "application/json"
+      string = Header.JSON.rawValue
     case .FormURLEncoded:
-      string = "application/x-www-form-urlencoded"
+      string = Header.FormURLEncoded.rawValue
     case .MultipartFormData:
-      string = "multipart/form-data; boundary=\(boundary)"
+      string = Header.MultipartFormData.rawValue
     case .Custom(let value):
       string = value
     }

--- a/Sources/Request/ETagPolicy.swift
+++ b/Sources/Request/ETagPolicy.swift
@@ -1,4 +1,0 @@
-public enum ETagPolicy {
-  case Enabled
-  case Disabled
-}

--- a/Sources/Request/RequestCapsule.swift
+++ b/Sources/Request/RequestCapsule.swift
@@ -31,7 +31,7 @@ class RequestCapsule: NSObject, Requestable, NSCoding {
     message = request.message
     contentType = request.contentType
     etagPolicy = request.etagPolicy
-    storePolicy = .Unspecified
+    storePolicy = request.storePolicy
     cachePolicy = request.cachePolicy
   }
 

--- a/Sources/Request/RequestCapsule.swift
+++ b/Sources/Request/RequestCapsule.swift
@@ -1,0 +1,9 @@
+//
+//  RequestCapsule.swift
+//  Malibu
+//
+//  Created by Vadym Markov on 29/09/2016.
+//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
+//
+
+import Foundation

--- a/Sources/Request/RequestCapsule.swift
+++ b/Sources/Request/RequestCapsule.swift
@@ -42,9 +42,9 @@ class RequestCapsule: NSObject, Requestable, NSCoding {
       resource = aDecoder.decodeObjectForKey(Key.Resource.rawValue) as? String,
       parameters = aDecoder.decodeObjectForKey(Key.Parameters.rawValue) as? [String: AnyObject],
       headers = aDecoder.decodeObjectForKey(Key.Headers.rawValue) as? [String: String],
-      etagPolicy = ETagPolicy(rawValue: aDecoder.decodeIntegerForKey(Key.EtagPolicy.rawValue)),
-      storePolicy = StorePolicy(rawValue: aDecoder.decodeIntegerForKey(Key.StorePolicy.rawValue)),
-      cachePolicy = NSURLRequestCachePolicy(rawValue: UInt(aDecoder.decodeIntegerForKey(Key.CachePolicy.rawValue)))
+      etagPolicy = ETagPolicy(rawValue: aDecoder.decodeIntForKey(Key.EtagPolicy.rawValue)),
+      storePolicy = StorePolicy(rawValue: aDecoder.decodeIntForKey(Key.StorePolicy.rawValue)),
+      cachePolicy = NSURLRequestCachePolicy(rawValue: UInt(aDecoder.decodeIntForKey(Key.CachePolicy.rawValue)))
     else {
       return nil
     }
@@ -65,8 +65,8 @@ class RequestCapsule: NSObject, Requestable, NSCoding {
     aCoder.encodeObject(message.parameters, forKey: Key.Parameters.rawValue)
     aCoder.encodeObject(message.headers, forKey: Key.Headers.rawValue)
     aCoder.encodeObject(contentType.header, forKey: Key.ContentType.rawValue)
-    aCoder.encodeObject(etagPolicy.rawValue, forKey: Key.EtagPolicy.rawValue)
-    aCoder.encodeObject(storePolicy.rawValue, forKey: Key.StorePolicy.rawValue)
-    aCoder.encodeObject(cachePolicy.rawValue, forKey: Key.CachePolicy.rawValue)
+    aCoder.encodeInt(etagPolicy.rawValue, forKey: Key.EtagPolicy.rawValue)
+    aCoder.encodeInt(storePolicy.rawValue, forKey: Key.StorePolicy.rawValue)
+    aCoder.encodeInt(Int32(cachePolicy.rawValue), forKey: Key.CachePolicy.rawValue)
   }
 }

--- a/Sources/Request/RequestCapsule.swift
+++ b/Sources/Request/RequestCapsule.swift
@@ -1,9 +1,72 @@
-//
-//  RequestCapsule.swift
-//  Malibu
-//
-//  Created by Vadym Markov on 29/09/2016.
-//  Copyright © 2016 Hyper Interaktiv AS. All rights reserved.
-//
-
 import Foundation
+
+class RequestCapsule: NSObject, Requestable, NSCoding {
+
+  enum Key: String {
+    case Method
+    case Resource
+    case Parameters
+    case Headers
+    case ContentType
+    case EtagPolicy
+    case StorePolicy
+    case CachePolicy
+  }
+
+  let method: Method
+  var message: Message
+  let contentType: ContentType
+  let etagPolicy: ETagPolicy
+  let storePolicy: StorePolicy
+  let cachePolicy: NSURLRequestCachePolicy
+
+  var id: String {
+    return message.resource.URLString
+  }
+
+  // MARK: - Initialization
+
+  init(request: Requestable) {
+    method = request.method
+    message = request.message
+    contentType = request.contentType
+    etagPolicy = request.etagPolicy
+    storePolicy = .Unspecified
+    cachePolicy = request.cachePolicy
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    guard let
+      methodString = aDecoder.decodeObjectForKey(Key.Method.rawValue) as? String,
+      method = Method(rawValue: methodString),
+      resource = aDecoder.decodeObjectForKey(Key.Resource.rawValue) as? String,
+      parameters = aDecoder.decodeObjectForKey(Key.Parameters.rawValue) as? [String: AnyObject],
+      headers = aDecoder.decodeObjectForKey(Key.Headers.rawValue) as? [String: String],
+      etagPolicy = ETagPolicy(rawValue: aDecoder.decodeIntegerForKey(Key.EtagPolicy.rawValue)),
+      storePolicy = StorePolicy(rawValue: aDecoder.decodeIntegerForKey(Key.StorePolicy.rawValue)),
+      cachePolicy = NSURLRequestCachePolicy(rawValue: UInt(aDecoder.decodeIntegerForKey(Key.CachePolicy.rawValue)))
+    else {
+      return nil
+    }
+
+    self.method = method
+    self.message = Message(resource: resource, parameters: parameters, headers: headers)
+    self.contentType = ContentType(header: aDecoder.decodeObjectForKey(Key.ContentType.rawValue) as? String)
+    self.etagPolicy = etagPolicy
+    self.storePolicy = storePolicy
+    self.cachePolicy = cachePolicy
+  }
+
+  // MARK: - Encoding
+
+  func encodeWithCoder(aCoder: NSCoder) {
+    aCoder.encodeObject(method.rawValue, forKey: Key.Method.rawValue)
+    aCoder.encodeObject(message.resource.URLString, forKey: Key.Resource.rawValue)
+    aCoder.encodeObject(message.parameters, forKey: Key.Parameters.rawValue)
+    aCoder.encodeObject(message.headers, forKey: Key.Headers.rawValue)
+    aCoder.encodeObject(contentType.header, forKey: Key.ContentType.rawValue)
+    aCoder.encodeObject(etagPolicy.rawValue, forKey: Key.EtagPolicy.rawValue)
+    aCoder.encodeObject(storePolicy.rawValue, forKey: Key.StorePolicy.rawValue)
+    aCoder.encodeObject(cachePolicy.rawValue, forKey: Key.CachePolicy.rawValue)
+  }
+}

--- a/Sources/Request/RequestPolicies.swift
+++ b/Sources/Request/RequestPolicies.swift
@@ -1,0 +1,9 @@
+public enum ETagPolicy {
+  case Enabled
+  case Disabled
+}
+
+public enum StorePolicy {
+  case Unspecified
+  case Offline
+}

--- a/Sources/Request/RequestPolicies.swift
+++ b/Sources/Request/RequestPolicies.swift
@@ -1,9 +1,9 @@
-public enum ETagPolicy {
+public enum ETagPolicy: Int {
   case Enabled
   case Disabled
 }
 
-public enum StorePolicy {
+public enum StorePolicy: Int {
   case Unspecified
   case Offline
 }

--- a/Sources/Request/RequestPolicies.swift
+++ b/Sources/Request/RequestPolicies.swift
@@ -1,9 +1,9 @@
-public enum ETagPolicy: Int {
+public enum ETagPolicy: Int32 {
   case Enabled
   case Disabled
 }
 
-public enum StorePolicy: Int {
+public enum StorePolicy: Int32 {
   case Unspecified
   case Offline
 }

--- a/Sources/Request/RequestStorage.swift
+++ b/Sources/Request/RequestStorage.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public final class RequestStorage {
+  let key = "Offline.RequestStorage"
+
+  public static let shared: RequestStorage = RequestStorage()
+
+  public private(set) var requests = [String: NSURLRequest]()
+
+  private var userDefaults: NSUserDefaults {
+    return NSUserDefaults.standardUserDefaults()
+  }
+
+  // MARK: - Initialization
+
+  init() {
+    requests = load()
+  }
+
+  // MARK: - Save
+
+  public func save(request: NSURLRequest) {
+    guard let key = request.URL?.absoluteString else {
+      return
+    }
+
+    requests[key] = request
+    saveAll()
+  }
+
+  public func saveAll() {
+    let data = NSKeyedArchiver.archivedDataWithRootObject(requests)
+    userDefaults.setObject(data, forKey: key)
+    userDefaults.synchronize()
+  }
+
+  // MARK: - Remove
+
+  public func remove(request: NSURLRequest) {
+    guard let key = request.URL?.absoluteString else {
+      return
+    }
+
+    requests.removeValueForKey(key)
+    saveAll()
+  }
+
+  public func clear() {
+    requests.removeAll()
+    userDefaults.removeObjectForKey(key)
+    userDefaults.synchronize()
+  }
+
+  // MARK: - Load
+
+  func load() -> [String: NSURLRequest] {
+    guard let data = userDefaults.objectForKey(key) as? NSData,
+      dictionary = NSKeyedUnarchiver.unarchiveObjectWithData(data) as? [String: NSURLRequest]
+      else { return [:] }
+
+    return dictionary
+  }
+}

--- a/Sources/Request/RequestStorage.swift
+++ b/Sources/Request/RequestStorage.swift
@@ -1,11 +1,9 @@
 import Foundation
 
-public final class RequestStorage {
-  let key = "Offline.RequestStorage"
+final class RequestStorage {
 
-  public static let shared: RequestStorage = RequestStorage()
-
-  public private(set) var requests = [String: NSURLRequest]()
+  let key: String
+  private(set) var requests = [String: NSURLRequest]()
 
   private var userDefaults: NSUserDefaults {
     return NSUserDefaults.standardUserDefaults()
@@ -13,13 +11,14 @@ public final class RequestStorage {
 
   // MARK: - Initialization
 
-  init() {
+  init(name: String) {
+    key = "no.hyper.Malibu.RequestStorage.\(name)"
     requests = load()
   }
 
   // MARK: - Save
 
-  public func save(request: NSURLRequest) {
+  func save(request: NSURLRequest) {
     guard let key = request.URL?.absoluteString else {
       return
     }
@@ -28,7 +27,7 @@ public final class RequestStorage {
     saveAll()
   }
 
-  public func saveAll() {
+  func saveAll() {
     let data = NSKeyedArchiver.archivedDataWithRootObject(requests)
     userDefaults.setObject(data, forKey: key)
     userDefaults.synchronize()
@@ -36,7 +35,7 @@ public final class RequestStorage {
 
   // MARK: - Remove
 
-  public func remove(request: NSURLRequest) {
+  func remove(request: NSURLRequest) {
     guard let key = request.URL?.absoluteString else {
       return
     }
@@ -45,7 +44,7 @@ public final class RequestStorage {
     saveAll()
   }
 
-  public func clear() {
+  func clear() {
     requests.removeAll()
     userDefaults.removeObjectForKey(key)
     userDefaults.synchronize()

--- a/Sources/Request/RequestStorage.swift
+++ b/Sources/Request/RequestStorage.swift
@@ -2,7 +2,10 @@ import Foundation
 
 final class RequestStorage {
 
-  let key: String
+  static let domain = "no.hyper.Malibu.RequestStorage"
+
+  var key: String
+
   private(set) var requests = [String: NSURLRequest]()
 
   private var userDefaults: NSUserDefaults {
@@ -11,8 +14,8 @@ final class RequestStorage {
 
   // MARK: - Initialization
 
-  init(name: String) {
-    key = "no.hyper.Malibu.RequestStorage.\(name)"
+  init(name: String = "Default") {
+    key = "\(RequestStorage.domain).\(name)"
     requests = load()
   }
 
@@ -48,6 +51,16 @@ final class RequestStorage {
     requests.removeAll()
     userDefaults.removeObjectForKey(key)
     userDefaults.synchronize()
+  }
+
+  static func clearAll() {
+    let userDefaults = NSUserDefaults.standardUserDefaults()
+    let keys = userDefaults.dictionaryRepresentation().keys
+    let storageKeys = keys.filter { $0.containsString(domain) }
+
+    for key in storageKeys {
+      userDefaults.removeObjectForKey(key)
+    }
   }
 
   // MARK: - Load

--- a/Sources/Request/RequestStorage.swift
+++ b/Sources/Request/RequestStorage.swift
@@ -6,7 +6,7 @@ final class RequestStorage {
 
   var key: String
 
-  private(set) var requests = [String: NSURLRequest]()
+  private(set) var requests = [String: RequestCapsule]()
 
   private var userDefaults: NSUserDefaults {
     return NSUserDefaults.standardUserDefaults()
@@ -21,12 +21,8 @@ final class RequestStorage {
 
   // MARK: - Save
 
-  func save(request: NSURLRequest) {
-    guard let key = request.URL?.absoluteString else {
-      return
-    }
-
-    requests[key] = request
+  func save(capsule: RequestCapsule) {
+    requests[capsule.id] = capsule
     saveAll()
   }
 
@@ -38,12 +34,8 @@ final class RequestStorage {
 
   // MARK: - Remove
 
-  func remove(request: NSURLRequest) {
-    guard let key = request.URL?.absoluteString else {
-      return
-    }
-
-    requests.removeValueForKey(key)
+  func remove(capsule: RequestCapsule) {
+    requests.removeValueForKey(capsule.id)
     saveAll()
   }
 
@@ -65,9 +57,9 @@ final class RequestStorage {
 
   // MARK: - Load
 
-  func load() -> [String: NSURLRequest] {
+  func load() -> [String: RequestCapsule] {
     guard let data = userDefaults.objectForKey(key) as? NSData,
-      dictionary = NSKeyedUnarchiver.unarchiveObjectWithData(data) as? [String: NSURLRequest]
+      dictionary = NSKeyedUnarchiver.unarchiveObjectWithData(data) as? [String: RequestCapsule]
       else { return [:] }
 
     return dictionary

--- a/Sources/Request/RequestStorage.swift
+++ b/Sources/Request/RequestStorage.swift
@@ -6,7 +6,7 @@ final class RequestStorage {
 
   var key: String
 
-  private(set) var requests = [String: RequestCapsule]()
+  var requests = [String: RequestCapsule]()
 
   private var userDefaults: NSUserDefaults {
     return NSUserDefaults.standardUserDefaults()

--- a/Sources/Request/Requestable.swift
+++ b/Sources/Request/Requestable.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Requestable: NSCoding {
+public protocol Requestable {
   var method: Method { get }
   var message: Message { get set }
   var contentType: ContentType { get }

--- a/Sources/Request/Requestable.swift
+++ b/Sources/Request/Requestable.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Requestable {
+public protocol Requestable: NSCoding {
   var method: Method { get }
   var message: Message { get set }
   var contentType: ContentType { get }

--- a/Sources/Request/Requestable.swift
+++ b/Sources/Request/Requestable.swift
@@ -5,6 +5,7 @@ public protocol Requestable {
   var message: Message { get set }
   var contentType: ContentType { get }
   var etagPolicy: ETagPolicy { get }
+  var storePolicy: StorePolicy { get }
   var cachePolicy: NSURLRequestCachePolicy { get }
 
   func toURLRequest(baseURLString: URLStringConvertible?,
@@ -14,6 +15,10 @@ public protocol Requestable {
 public extension Requestable {
 
   // MARK: - Default implementations
+
+  var storePolicy: StorePolicy {
+    return .Unspecified
+  }
 
   var cachePolicy: NSURLRequestCachePolicy {
     return .UseProtocolCachePolicy


### PR DESCRIPTION
@zenangst @RamonGilabert @onmyway133 
💥 Request storage is migrated from https://github.com/hyperoslo/Offline. But it's not just a copy.  It adopted to Malibu types and works with promises.

- Want to store request to `NSUserDefaults` when there is no network connection to replay it later?
```swift
struct GETRequest: GETRequestable {
  var message = Message(resource: "http://hyper.no")
  var storePolicy: StorePolicy = .Offline

  init(parameters: [String: AnyObject] = [:], headers: [String: String] = [:]) {
    message.parameters = parameters
    message.headers = headers
  }
}
```

- Want to replay cached requests?
```swift
networking.replay().done({ result
  print(result)
})
```

Request storage is networking-specific, and while it replays cached request it will be set to `Sync` mode. Cached request will go through normal request lifecycle in `Malibu`, with applied middleware and pre-process operations.