### PR TITLE
Make execute method public

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -135,7 +135,7 @@ public final class Networking: NSObject {
     return nextRide
   }
 
-  func execute(_ request: Requestable) -> Ride {
+  public func execute(_ request: Requestable) -> Ride {
     let ride = Ride()
     let beforePromise = Promise<Void>()
 


### PR DESCRIPTION
So that we can pass the certain `Requestable` object, ideal for someone migrating to Malibu 😄 