### PR TITLE
Fix query builder

### DIFF
--- a/Sources/Helpers/QueryBuilder.swift
+++ b/Sources/Helpers/QueryBuilder.swift
@@ -62,16 +62,14 @@ public struct QueryBuilder {
       var index = string.startIndex
 
       while index != string.endIndex {
-        guard let endIndex = string.index(index, offsetBy: 50, limitedBy: string.endIndex) else {
-          break
-        }
-
+        let endIndex = string.index(index, offsetBy: 50, limitedBy: string.endIndex) ?? string.endIndex
         let range = Range(index..<endIndex)
         let substring = string.substring(with: range)
 
-        index = endIndex
         escapedString += substring.addingPercentEncoding(
           withAllowedCharacters: allowedCharacters as CharacterSet) ?? substring
+
+        index = endIndex
       }
     }
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -104,7 +104,6 @@ public final class Networking: NSObject {
         return ride
     }
 
-
     let etagPromise = ride.then { [weak self] result -> Wave in
       self?.saveEtag(request: request, response: result.response)
       return result


### PR DESCRIPTION
According to `index` function

> An index offset by n from the index i, unless that index would be beyond limit in the direction of movement. In that case, the method returns nil.

This won't work for string with count smaller than batch size because of the guard
So this fixes by fallbacks to `string.endIndex`. Hope the very small potion of iOS 8.1 and 8.2 users will like this 😄 