### PR TITLE
Make Header public

### DIFF
--- a/MalibuTests/Specs/Request/HeaderSpec.swift
+++ b/MalibuTests/Specs/Request/HeaderSpec.swift
@@ -44,6 +44,7 @@ class HeaderSpec: QuickSpec {
       describe(".defaultHeaders") {
         it("returns a correct value") {
           let expected = [
+            "Accept-Language": Header.acceptLanguage,
             "Accept-Encoding": Header.acceptEncoding,
             "User-Agent": Header.userAgent
           ]

--- a/Sources/Request/Header.swift
+++ b/Sources/Request/Header.swift
@@ -2,16 +2,16 @@ import Foundation
 
 public struct Header {
 
-  public static let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
+  static let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
 
-  public static var acceptLanguage: String {
+  static var acceptLanguage: String {
     return Locale.preferredLanguages.prefix(6).enumerated().map { index, languageCode in
       let quality = 1.0 - (Double(index) * 0.1)
       return "\(languageCode);q=\(quality)"
       }.joined(separator: ", ")
   }
 
-  public static let userAgent: String = {
+  static let userAgent: String = {
     var string = "Malibu"
 
     if let info = Bundle.main.infoDictionary {
@@ -34,7 +34,7 @@ public struct Header {
     ]
   }()
 
-  public static func authentication(username: String, password: String) -> String? {
+  static func authentication(username: String, password: String) -> String? {
     let credentials = "\(username):\(password)"
 
     guard let credentialsData = credentials.data(using: String.Encoding.utf8) else {

--- a/Sources/Request/Header.swift
+++ b/Sources/Request/Header.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-struct Header {
+public struct Header {
 
-  static let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
+  public static let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
 
-  static var acceptLanguage: String {
+  public static var acceptLanguage: String {
     return Locale.preferredLanguages.prefix(6).enumerated().map { index, languageCode in
       let quality = 1.0 - (Double(index) * 0.1)
       return "\(languageCode);q=\(quality)"
       }.joined(separator: ", ")
   }
 
-  static let userAgent: String = {
+  public static let userAgent: String = {
     var string = "Malibu"
 
     if let info = Bundle.main.infoDictionary {
@@ -26,14 +26,15 @@ struct Header {
     return string
   }()
 
-  static let defaultHeaders: [String: String] = {
+  public static let defaultHeaders: [String: String] = {
     return [
       "Accept-Encoding": acceptEncoding,
+      "Accept-Language": acceptLanguage,
       "User-Agent": userAgent
     ]
   }()
 
-  static func authentication(username: String, password: String) -> String? {
+  public static func authentication(username: String, password: String) -> String? {
     let credentials = "\(username):\(password)"
 
     guard let credentialsData = credentials.data(using: String.Encoding.utf8) else {


### PR DESCRIPTION
- We have `accept language`, so I think that should be in the default headers, too 😄 
- Make `Header` public, as when we have our own login networking, we can reuse these default headers