### PR TITLE
Fix version to use version string

### DIFF
--- a/Sources/Request/Header.swift
+++ b/Sources/Request/Header.swift
@@ -17,7 +17,7 @@ public struct Header {
     if let info = Bundle.main.infoDictionary {
       let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
       let bundle = info[kCFBundleIdentifierKey as String] as? String ?? "Unknown"
-      let version = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
+      let version = info["CFBundleShortVersionString"] as? String ?? "Unknown"
       let build = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
 
       string = "\(executable)/\(version) (\(bundle); build:\(build); \(Utils.osInfo)) \(Utils.frameworkInfo)"


### PR DESCRIPTION
Before

```
MyApp/32 (com.example.MyApp; build:32; iOS 10.1.1) Malibu/2.0.1
```

After

```
MyApp/0.0.26 (com.example.MyApp; build:32; iOS 10.1.1) Malibu/2.0.1
```