### PR TITLE
Construct request URL

### DIFF
--- a/MalibuTests/Specs/Request/RequestableSpec.swift
+++ b/MalibuTests/Specs/Request/RequestableSpec.swift
@@ -56,7 +56,7 @@ class RequestableSpec: QuickSpec {
 
           context("with base URL") {
             it("does not throw an error and returns created URLRequest") {
-              request.message.resource = "about"
+              request.message.resource = "/about"
 
               expect {
                 urlRequest = try request.toUrlRequest(baseUrl: "http://hyper.no")

--- a/MalibuTests/Specs/Request/RequestableSpec.swift
+++ b/MalibuTests/Specs/Request/RequestableSpec.swift
@@ -56,11 +56,33 @@ class RequestableSpec: QuickSpec {
 
           context("with base URL") {
             it("does not throw an error and returns created URLRequest") {
-              request.message.resource = "/about"
+              request.message.resource = "about"
 
               expect {
                 urlRequest = try request.toUrlRequest(baseUrl: "http://hyper.no")
               }.toNot(throwError())
+              expect(urlRequest.url?.absoluteString).to(equal("http://hyper.no/about"))
+            }
+          }
+
+          context("with base URL with slash") {
+            it("does not throw an error and returns created URLRequest") {
+              request.message.resource = "/about"
+
+              expect {
+                urlRequest = try request.toUrlRequest(baseUrl: "http://hyper.no/")
+                }.toNot(throwError())
+              expect(urlRequest.url?.absoluteString).to(equal("http://hyper.no/about"))
+            }
+          }
+
+          context("with base URL without slash") {
+            it("does not throw an error and returns created URLRequest") {
+              request.message.resource = "about"
+
+              expect {
+                urlRequest = try request.toUrlRequest(baseUrl: "http://hyper.no")
+                }.toNot(throwError())
               expect(urlRequest.url?.absoluteString).to(equal("http://hyper.no/about"))
             }
           }

--- a/Sources/Request/Requestable.swift
+++ b/Sources/Request/Requestable.swift
@@ -27,25 +27,10 @@ public extension Requestable {
   func toUrlRequest(baseUrl: URLStringConvertible? = nil,
                     additionalHeaders: [String: String] = [:]) throws -> URLRequest {
     let prefix = baseUrl?.urlString ?? ""
-    let url: URL?
+    let url = try concatURL(baseUrl: baseUrl?.urlString)
 
-    if let baseUrl = baseUrl {
-      var path = message.resource.urlString
-      if path.hasPrefix("/") {
-        path.remove(at: path.startIndex)
-      }
-
-      url = URL(string: baseUrl.urlString)?.appendingPathComponent(path)
-    } else {
-      url = URL(string: message.resource.urlString)
-    }
-
-    guard let fullUrl = url else {
-      throw NetworkError.invalidRequestURL
-    }
-
-    let builtUrl = try buildUrl(from: fullUrl)
-    var request = URLRequest(url: builtUrl)
+    let requestUrl = try buildUrl(from: url)
+    var request = URLRequest(url: requestUrl)
 
     request.httpMethod = method.rawValue
     request.cachePolicy = cachePolicy
@@ -120,5 +105,26 @@ public extension Requestable {
 
   var key: String {
     return "\(method.rawValue) \(message.resource.urlString)"
+  }
+
+  func concatURL(baseUrl: URLStringConvertible?) throws -> URL {
+    let url: URL?
+
+    if let baseUrl = baseUrl {
+      var path = message.resource.urlString
+      if path.hasPrefix("/") {
+        path.remove(at: path.startIndex)
+      }
+
+      url = URL(string: baseUrl.urlString)?.appendingPathComponent(path)
+    } else {
+      url = URL(string: message.resource.urlString)
+    }
+
+    guard let fullUrl = url else {
+      throw NetworkError.invalidRequestURL
+    }
+
+    return fullUrl
   }
 }


### PR DESCRIPTION
This handles the url for the user, so there is less room for errors with slashes. User can specify

- baseURL: `http://hyper.no/` or `http://hyper.no`
- path: `about` or `/about`