### PR TITLE
Feature: ResponseConvertible and mock provider

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -17,8 +17,8 @@
 		D5339AF71D9C6C5900E8A7AD /* RequestStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */; };
 		D53FBEAA1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
 		D53FBEAB1D9922BB0014AE4A /* ConcurrentOperationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */; };
-		D5445A0A1E3CE16F00445406 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5445A091E3CE16F00445406 /* Endpoint.swift */; };
-		D5445A0B1E3CE16F00445406 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5445A091E3CE16F00445406 /* Endpoint.swift */; };
+		D5445A0A1E3CE16F00445406 /* RequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5445A091E3CE16F00445406 /* RequestConvertible.swift */; };
+		D5445A0B1E3CE16F00445406 /* RequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5445A091E3CE16F00445406 /* RequestConvertible.swift */; };
 		D549C8561C8F661E00588A0C /* JsonSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JsonSerializerSpec.swift */; };
 		D549C8571C8F661E00588A0C /* JsonSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8551C8F661E00588A0C /* JsonSerializerSpec.swift */; };
 		D549C8591C8F6BB500588A0C /* DataSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */; };
@@ -189,7 +189,7 @@
 		D503D3A41C8EC7550009BDAD /* NetworkPromiseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPromiseSpec.swift; sourceTree = "<group>"; };
 		D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestStorage.swift; sourceTree = "<group>"; };
 		D53FBEA91D9922BB0014AE4A /* ConcurrentOperationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperationSpec.swift; sourceTree = "<group>"; };
-		D5445A091E3CE16F00445406 /* Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		D5445A091E3CE16F00445406 /* RequestConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestConvertible.swift; sourceTree = "<group>"; };
 		D549C8551C8F661E00588A0C /* JsonSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C8581C8F6BB500588A0C /* DataSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSerializerSpec.swift; sourceTree = "<group>"; };
 		D549C85B1C8F6C8800588A0C /* StringSerializerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringSerializerSpec.swift; sourceTree = "<group>"; };
@@ -418,7 +418,7 @@
 				D5C1D06E1CB3D49F00A076D6 /* Ride.swift */,
 				D5339AF51D9C6C5900E8A7AD /* RequestStorage.swift */,
 				D5E8EDC21D9D865B0087690A /* RequestCapsule.swift */,
-				D5445A091E3CE16F00445406 /* Endpoint.swift */,
+				D5445A091E3CE16F00445406 /* RequestConvertible.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -897,7 +897,7 @@
 				D5EB7C601CB01E73003A3BA9 /* RequestPolicies.swift in Sources */,
 				DA5B4CF81C8E5936004E21ED /* NetworkError.swift in Sources */,
 				D5A3DC881CD164750084F451 /* Logging.swift in Sources */,
-				D5445A0A1E3CE16F00445406 /* Endpoint.swift in Sources */,
+				D5445A0A1E3CE16F00445406 /* RequestConvertible.swift in Sources */,
 				D5B9650D1C922BCF0099D2F9 /* ContentType.swift in Sources */,
 				D5C1D06F1CB3D49F00A076D6 /* Ride.swift in Sources */,
 				D5B9651A1C922BDC0099D2F9 /* MimeType.swift in Sources */,
@@ -983,7 +983,7 @@
 				D5EB7C611CB01E73003A3BA9 /* RequestPolicies.swift in Sources */,
 				DA5B4CF91C8E5936004E21ED /* NetworkError.swift in Sources */,
 				D5A3DC891CD164750084F451 /* Logging.swift in Sources */,
-				D5445A0B1E3CE16F00445406 /* Endpoint.swift in Sources */,
+				D5445A0B1E3CE16F00445406 /* RequestConvertible.swift in Sources */,
 				D5B9650E1C922BCF0099D2F9 /* ContentType.swift in Sources */,
 				D5C1D0701CB3D49F00A076D6 /* Ride.swift in Sources */,
 				D5B9651B1C922BDC0099D2F9 /* MimeType.swift in Sources */,

--- a/MalibuTests/Helpers/Mocks.swift
+++ b/MalibuTests/Helpers/Mocks.swift
@@ -21,7 +21,7 @@ enum TestService: Endpoint {
     case .fetchPosts:
       return Request.get("posts")
     case .showPost(let id):
-      return Request.get("posts/\(id)", mock: Mock(json: ["title": "Test"]))
+      return Request.get("posts/\(id)")
     case .createPost(let title):
       return Request.post("posts", parameters: ["title": title])
     case .replacePost(let id, let title):

--- a/MalibuTests/Helpers/Mocks.swift
+++ b/MalibuTests/Helpers/Mocks.swift
@@ -4,7 +4,7 @@ import When
 
 // MARK: - Service
 
-enum TestService: Endpoint {
+enum TestService: RequestConvertible {
   case fetchPosts
   case showPost(id: Int)
   case createPost(title: String)

--- a/MalibuTests/Specs/NetworkingSpec.swift
+++ b/MalibuTests/Specs/NetworkingSpec.swift
@@ -2,18 +2,15 @@
 import Quick
 import Nimble
 
+// MARK: - Specs
+
 class NetworkingSpec: QuickSpec {
 
   override func spec() {
     describe("Networking") {
-      var networking: Networking<TestService>!
-
-      beforeEach {
-        networking = Networking(mockBehavior: .delayed(seconds: 0))
-      }
-
       describe("#init") {
         it("sets default configuration to the session") {
+          let networking = Networking<TestService>()
           expect(networking.session.configuration).to(equal(SessionConfiguration.default.value))
         }
       }
@@ -21,6 +18,11 @@ class NetworkingSpec: QuickSpec {
       describe("#request") {
         context("when request has a mock") {
           it("returns a mock data") {
+            let mockProvider = MockProvider<TestService> { _ in
+              return Mock(json: ["title": "Test"])
+            }
+
+            let networking = Networking(mockProvider: mockProvider)
             let expectation = self.expectation(description: "Request")
 
             networking.request(.showPost(id: 1)).toJsonDictionary().done({ json in

--- a/Playground-iOS.playground/Contents.swift
+++ b/Playground-iOS.playground/Contents.swift
@@ -38,7 +38,7 @@ struct User: CustomStringConvertible {
 
 // Service
 
-enum PlaceholderService: Endpoint {
+enum Endpoint: RequestConvertible {
   case fetchUsers
   case createUser(id: Int, name: String, username: String, email: String)
 
@@ -65,7 +65,7 @@ enum PlaceholderService: Endpoint {
 }
 
 // Create and configure Networking.
-let networking = Networking<PlaceholderService>()
+let networking = Networking<Endpoint>()
 
 // Make GET request
 networking.request(.fetchUsers)

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -10,11 +10,11 @@ public enum NetworkingMode {
 // MARK: - Mocks
 
 public struct MockProvider<R: RequestConvertible> {
-  let resolveMock: (R) -> Mock?
+  let resolver: (R) -> Mock?
   let delay: TimeInterval
 
-  public init(delay: TimeInterval = 0, resolveMock: @escaping (R) -> Mock?) {
-    self.resolveMock = resolveMock
+  public init(delay: TimeInterval = 0, resolver: @escaping (R) -> Mock?) {
+    self.resolver = resolver
     self.delay = delay
   }
 }
@@ -113,7 +113,7 @@ extension Networking {
   public func request(_ requestConvertible: R) -> Ride {
     var mockBehavior: MockBehavior?
 
-    if let mockProvider = mockProvider, let mock = mockProvider.resolveMock(requestConvertible) {
+    if let mockProvider = mockProvider, let mock = mockProvider.resolver(requestConvertible) {
       mockBehavior = MockBehavior(mock: mock, delay: mockProvider.delay)
     }
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -10,11 +10,11 @@ public enum NetworkingMode {
 // MARK: - Mocks
 
 public struct MockProvider<E: Endpoint> {
-  let resolve: (E) -> Mock?
+  let resolveMock: (E) -> Mock?
   let delay: TimeInterval
 
-  public init(resolve: @escaping (E) -> Mock?, delay: TimeInterval) {
-    self.resolve = resolve
+  public init(delay: TimeInterval = 0, resolveMock: @escaping (E) -> Mock?) {
+    self.resolveMock = resolveMock
     self.delay = delay
   }
 }
@@ -113,7 +113,7 @@ extension Networking {
   public func request(_ endpoint: E) -> Ride {
     var mockBehavior: MockBehavior?
 
-    if let mockProvider = mockProvider, let mock = mockProvider.resolve(endpoint) {
+    if let mockProvider = mockProvider, let mock = mockProvider.resolveMock(endpoint) {
       mockBehavior = MockBehavior(mock: mock, delay: mockProvider.delay)
     }
 

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -7,7 +7,7 @@ public struct Request: Equatable {
   public let resource: URLStringConvertible
   public let parameters: [String: Any]
   public let headers: [String: String]
-  public let mock: Mock?
+  public var mock: Mock?
   public let contentType: ContentType
   public let etagPolicy: EtagPolicy
   public let storePolicy: StorePolicy

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -7,7 +7,6 @@ public struct Request: Equatable {
   public let resource: URLStringConvertible
   public let parameters: [String: Any]
   public let headers: [String: String]
-  public var mock: Mock?
   public let contentType: ContentType
   public let etagPolicy: EtagPolicy
   public let storePolicy: StorePolicy
@@ -18,7 +17,6 @@ public struct Request: Equatable {
               contentType: ContentType,
               parameters: [String: Any] = [:],
               headers: [String: String] = [:],
-              mock: Mock? = nil,
               etagPolicy: EtagPolicy = .disabled,
               storePolicy: StorePolicy = .unspecified,
               cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) {
@@ -27,7 +25,6 @@ public struct Request: Equatable {
     self.contentType = contentType
     self.parameters = parameters
     self.headers = headers
-    self.mock = mock
     self.etagPolicy = etagPolicy
     self.storePolicy = storePolicy
     self.cachePolicy = cachePolicy
@@ -41,7 +38,6 @@ public extension Request {
   public static func get(_ resource: URLStringConvertible,
                          parameters: [String: Any] = [:],
                          headers: [String: String] = [:],
-                         mock: Mock? = nil,
                          etagPolicy: EtagPolicy = .enabled,
                          storePolicy: StorePolicy = .unspecified,
                          cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) -> Request {
@@ -51,7 +47,6 @@ public extension Request {
       contentType: .query,
       parameters: parameters,
       headers: headers,
-      mock: mock,
       etagPolicy: .enabled,
       storePolicy: storePolicy,
       cachePolicy: cachePolicy
@@ -62,7 +57,6 @@ public extension Request {
                           contentType: ContentType = .json,
                           parameters: [String: Any] = [:],
                           headers: [String: String] = [:],
-                          mock: Mock? = nil,
                           storePolicy: StorePolicy = .unspecified,
                           cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) -> Request {
     return Request(
@@ -71,7 +65,6 @@ public extension Request {
       contentType: contentType,
       parameters: parameters,
       headers: headers,
-      mock: mock,
       etagPolicy: .disabled,
       storePolicy: storePolicy,
       cachePolicy: cachePolicy
@@ -82,7 +75,6 @@ public extension Request {
                          contentType: ContentType = .json,
                          parameters: [String: Any] = [:],
                          headers: [String: String] = [:],
-                         mock: Mock? = nil,
                          etagPolicy: EtagPolicy = .enabled,
                          storePolicy: StorePolicy = .unspecified,
                          cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) -> Request {
@@ -92,7 +84,6 @@ public extension Request {
       contentType: contentType,
       parameters: parameters,
       headers: headers,
-      mock: mock,
       etagPolicy: etagPolicy,
       storePolicy: storePolicy,
       cachePolicy: cachePolicy
@@ -103,7 +94,6 @@ public extension Request {
                            contentType: ContentType = .json,
                            parameters: [String: Any] = [:],
                            headers: [String: String] = [:],
-                           mock: Mock? = nil,
                            etagPolicy: EtagPolicy = .enabled,
                            storePolicy: StorePolicy = .unspecified,
                            cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) -> Request {
@@ -113,7 +103,6 @@ public extension Request {
       contentType: contentType,
       parameters: parameters,
       headers: headers,
-      mock: mock,
       etagPolicy: etagPolicy,
       storePolicy: storePolicy,
       cachePolicy: cachePolicy
@@ -124,7 +113,6 @@ public extension Request {
                             contentType: ContentType = .query,
                             parameters: [String: Any] = [:],
                             headers: [String: String] = [:],
-                            mock: Mock? = nil,
                             etagPolicy: EtagPolicy = .disabled,
                             storePolicy: StorePolicy = .unspecified,
                             cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) -> Request {
@@ -134,7 +122,6 @@ public extension Request {
       contentType: contentType,
       parameters: parameters,
       headers: headers,
-      mock: mock,
       etagPolicy: etagPolicy,
       storePolicy: storePolicy,
       cachePolicy: cachePolicy
@@ -145,7 +132,6 @@ public extension Request {
                           contentType: ContentType = .query,
                           parameters: [String: Any] = [:],
                           headers: [String: String] = [:],
-                          mock: Mock? = nil,
                           etagPolicy: EtagPolicy = .disabled,
                           storePolicy: StorePolicy = .unspecified,
                           cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) -> Request {
@@ -155,7 +141,6 @@ public extension Request {
       contentType: contentType,
       parameters: parameters,
       headers: headers,
-      mock: mock,
       etagPolicy: etagPolicy,
       storePolicy: storePolicy,
       cachePolicy: cachePolicy

--- a/Sources/Request/RequestConvertible.swift
+++ b/Sources/Request/RequestConvertible.swift
@@ -1,6 +1,6 @@
-// MARK: - Endpoint
+// MARK: - RequestConvertible
 
-public protocol Endpoint {
+public protocol RequestConvertible {
 
   static var baseUrl: URLStringConvertible { get }
   static var headers: [String: String] { get }
@@ -10,7 +10,7 @@ public protocol Endpoint {
 
 // MARK: - Defaults
 
-struct AnyEndpoint: Endpoint {
+struct AnyEndpoint: RequestConvertible {
 
   static let baseUrl: URLStringConvertible = ""
   static let headers: [String: String] = [:]


### PR DESCRIPTION
⚠️ **Breaking change** ⚠️ 

1) `Endpoint` protocol was renamed to `RequestConvertible` in order to make it more descriptive.
2) Mock property is removed from `Request`. When the mock is created in one single place it is not really flexible for unit testing if you want to inject JSON dictionary or custom file dynamically. That's why `MockProvider` was introduced in order to improve mock behaviour:

In order to start mocking you have to do the following:

**Create a mock provider**

```swift
// Delay is optional, 0.0 by default.
let mockProvider = MockProvider(delay: 1.0) { endpoint in
  switch endpoint {
    case .fetchBoards:
      // With response data from a file:
      return Mock(fileName: "boards.json")
    case .showBoard(let id):
      // With response from JSON dictionary:
      return Mock(json: ["id": 1, "title": "Balsa Fish"])
    case .updateBoard(let id, let title):
      // `Data` mock:
      return Mock(
        // Needed response
        response: mockedResponse,
        // Response data
        data: responseData,
        // Custom error, `nil` by default
        error: customError
      )
    default:
      return nil
  }
}
```

**Create a networking instance with your mock provider**

Both real and fake requests can be used in a mix:
```swift
let networking = Networking<SharkywatersEndpoint>(mockProvider: mockProvider)
```