### PR TITLE
Improve: request convertable base url

### DIFF
--- a/MalibuTests/Helpers/Mocks.swift
+++ b/MalibuTests/Helpers/Mocks.swift
@@ -13,7 +13,7 @@ enum TestService: RequestConvertible {
   case deletePost(id: Int)
   case head
 
-  static var baseUrl: URLStringConvertible = "http://api.loc"
+  static var baseUrl: URLStringConvertible? = "http://api.loc"
   static var headers: [String: String] = [:]
 
   var request: Request {

--- a/MalibuTests/Specs/Response/MockSpec.swift
+++ b/MalibuTests/Specs/Response/MockSpec.swift
@@ -9,7 +9,7 @@ class MockSpec: QuickSpec {
     describe("Mock") {
       var mock: Mock!
       let request = TestService.fetchPosts.request
-      var response = HTTPURLResponse(url: URL(string: TestService.baseUrl.urlString)!,
+      var response = HTTPURLResponse(url: URL(string: TestService.baseUrl!.urlString)!,
                                      statusCode: 200, httpVersion: "HTTP/2.0", headerFields: nil)!
       let data = "test".data(using: String.Encoding.utf32)
       let error = NetworkError.noDataInResponse

--- a/Playground-iOS.playground/Contents.swift
+++ b/Playground-iOS.playground/Contents.swift
@@ -42,7 +42,7 @@ enum Endpoint: RequestConvertible {
   case fetchUsers
   case createUser(id: Int, name: String, username: String, email: String)
 
-  static let baseUrl: URLStringConvertible = "http://jsonplaceholder.typicode.com/"
+  static let baseUrl: URLStringConvertible? = "http://jsonplaceholder.typicode.com/"
   static let sessionConfiguration: SessionConfiguration = .default
 
   // Additional headers will be used in the each request.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ enum SharkywatersEndpoint: RequestConvertible {
   case deleteBoard(id: Int)
 
   // Every request will be scoped by the base url
-  static var baseUrl: URLStringConvertible = "http://sharkywaters.com/api/"
+  // Base url is recommended, but optional
+  static var baseUrl: URLStringConvertible? = "http://sharkywaters.com/api/"
 
   // Additional headers for every request
   static var headers: [String: String] = [

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -81,7 +81,8 @@ public final class Networking<R: RequestConvertible>: NSObject, URLSessionDelega
 
   public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
     guard
-      let baseURL = NSURL(string: R.baseUrl.urlString),
+      let urlString = R.baseUrl?.urlString,
+      let baseURL = NSURL(string: urlString),
       let serverTrust = challenge.protectionSpace.serverTrust
       else { return }
 
@@ -235,7 +236,7 @@ extension Networking {
       return
     }
 
-    let prefix = R.baseUrl.urlString
+    let prefix = R.baseUrl?.urlString ?? ""
 
     EtagStorage().add(value: etag, forKey: request.etagKey(prefix: prefix))
   }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -82,7 +82,7 @@ public final class Networking<R: RequestConvertible>: NSObject, URLSessionDelega
   public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
     guard
       let urlString = R.baseUrl?.urlString,
-      let baseURL = NSURL(string: urlString),
+      let baseURL = URL(string: urlString),
       let serverTrust = challenge.protectionSpace.serverTrust
       else { return }
 

--- a/Sources/Request/RequestConvertible.swift
+++ b/Sources/Request/RequestConvertible.swift
@@ -2,7 +2,7 @@
 
 public protocol RequestConvertible {
 
-  static var baseUrl: URLStringConvertible { get }
+  static var baseUrl: URLStringConvertible? { get }
   static var headers: [String: String] { get }
 
   var request: Request { get }
@@ -12,7 +12,7 @@ public protocol RequestConvertible {
 
 struct AnyEndpoint: RequestConvertible {
 
-  static let baseUrl: URLStringConvertible = ""
+  static let baseUrl: URLStringConvertible? = nil
   static let headers: [String: String] = [:]
   public let request: Request
 }


### PR DESCRIPTION
This PR aims to fix https://github.com/hyperoslo/Malibu/issues/61 by making `baseUrl` in `RequestConvertible` optional.

```swift
static var baseUrl: URLStringConvertible? { get }
```

`let backfootSurfer = Networking<AnyEndpoint>()` didn't work before because its `baseUrl` was an empty string, which is wrong and breaks the logic of building the final request URL. And actually I think it makes sense to have optional `baseUrl` in `RequestConvertible` implementations, for cases when you want to group requests without any shared host.