### PR TITLE
Fix: authentication challenge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 - xcodebuild clean build -project Malibu.xcodeproj -scheme "Malibu-Mac" -sdk macosx
 - xcodebuild test -project Malibu.xcodeproj -scheme "Malibu-Mac" -sdk macosx
 - xcodebuild clean build -project Malibu.xcodeproj -scheme "Malibu-iOS" -sdk iphonesimulator
-- xcodebuild test -project Malibu.xcodeproj -scheme "Malibu-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0'
+- xcodebuild test -project Malibu.xcodeproj -scheme "Malibu-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' | xcpretty
 
 notifications:
   email: false

--- a/MalibuTests/Specs/NetworkingSpec.swift
+++ b/MalibuTests/Specs/NetworkingSpec.swift
@@ -5,7 +5,7 @@ import Nimble
 // MARK: - Mocks
 
 
-class ChallengeSender: NSObject, URLAuthenticationChallengeSender {
+private class ChallengeSenderMock: NSObject, URLAuthenticationChallengeSender {
 
   func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
   func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
@@ -119,7 +119,7 @@ class NetworkingSpec: QuickSpec {
 
   private func createAuthenticationChallenge(protectionSpace: URLProtectionSpace,
                                              previousFailureCount: Int) -> URLAuthenticationChallenge {
-    let sender = ChallengeSender()
+    let sender = ChallengeSenderMock()
 
     return URLAuthenticationChallenge(
       protectionSpace: protectionSpace,

--- a/MalibuTests/Specs/NetworkingSpec.swift
+++ b/MalibuTests/Specs/NetworkingSpec.swift
@@ -2,6 +2,16 @@
 import Quick
 import Nimble
 
+// MARK: - Mocks
+
+
+class ChallengeSender: NSObject, URLAuthenticationChallengeSender {
+
+  func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+  func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+  func cancel(_ challenge: URLAuthenticationChallenge) {}
+}
+
 // MARK: - Specs
 
 class NetworkingSpec: QuickSpec {
@@ -34,6 +44,101 @@ class NetworkingSpec: QuickSpec {
           }
         }
       }
+
+      describe("#urlSession:didReceiveChallenge:completionHandler:") {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+
+        context("with NSURLAuthenticationMethodServerTrust") {
+          let protectionSpace = self.createProtectionSpace(
+            authenticationMethod: NSURLAuthenticationMethodServerTrust
+          )
+          let challenge = self.createAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            previousFailureCount: 0
+          )
+
+          context("with baseUrl and no serverTrust") {
+            it("passess valid parameters to completion") {
+              let networking = Networking<TestService>()
+              networking.urlSession(session, didReceive: challenge) { disposition, credential in
+                expect(disposition == .performDefaultHandling).to(beTrue())
+                expect(credential).to(beNil())
+              }
+            }
+          }
+
+          context("without baseUrl") {
+            it("passess valid parameters to completion") {
+              let networking = Networking<AnyEndpoint>()
+              networking.urlSession(session, didReceive: challenge) { disposition, credential in
+                expect(disposition == .performDefaultHandling).to(beTrue())
+                expect(credential).to(beNil())
+              }
+            }
+          }
+        }
+
+        context("with other authentication methods") {
+          let protectionSpace = self.createProtectionSpace(
+            authenticationMethod: NSURLAuthenticationMethodClientCertificate
+          )
+
+          context("with one previous failure") {
+            it("passess valid parameters to completion") {
+              let networking = Networking<TestService>()
+              let challenge = self.createAuthenticationChallenge(
+                protectionSpace: protectionSpace,
+                previousFailureCount: 1
+              )
+
+              networking.urlSession(session, didReceive: challenge) { disposition, credential in
+                expect(disposition == .rejectProtectionSpace).to(beTrue())
+                expect(credential).to(beNil())
+              }
+            }
+          }
+
+          context("with no previous failures and no defaultCredential") {
+            it("passess valid parameters to completion") {
+              let networking = Networking<AnyEndpoint>()
+              let challenge = self.createAuthenticationChallenge(
+                protectionSpace: protectionSpace,
+                previousFailureCount: 0
+              )
+              
+              networking.urlSession(session, didReceive: challenge) { disposition, credential in
+                expect(disposition == .performDefaultHandling).to(beTrue())
+                expect(credential).to(beNil())
+              }
+            }
+          }
+        }
+      }
     }
+  }
+
+  private func createAuthenticationChallenge(protectionSpace: URLProtectionSpace,
+                                             previousFailureCount: Int) -> URLAuthenticationChallenge {
+    let sender = ChallengeSender()
+
+    return URLAuthenticationChallenge(
+      protectionSpace: protectionSpace,
+      proposedCredential: nil,
+      previousFailureCount: previousFailureCount,
+      failureResponse: nil,
+      error: nil,
+      sender: sender
+    )
+  }
+
+  private func createProtectionSpace(authenticationMethod: String,
+                                     host: String = "http://api.loc") -> URLProtectionSpace {
+    return URLProtectionSpace (
+      host: host,
+      port: 0880,
+      protocol: nil,
+      realm: nil,
+      authenticationMethod: authenticationMethod
+    )
   }
 }


### PR DESCRIPTION
The way we handled authentication challenges doesn't handle all the cases, basically it worked only when there is a base URL. Now we do multiple validations and call `completionHandler` in the end of the delegate function. 