### PR TITLE
Suspend and resume networking

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -110,6 +110,14 @@ public final class Networking<R: RequestConvertible>: NSObject, URLSessionDelega
     completionHandler(disposition, credential)
   }
 
+  public func resume() {
+    queue.isSuspended = false
+  }
+
+  public func suspend() {
+    queue.isSuspended = true
+  }
+
   func reset(mode: NetworkingMode) {
     self.mode = mode
 


### PR DESCRIPTION
It could be useful to suspend and resume operation queue, for example during refresh token tasks.