### PR TITLE
Delay URL request creation

### DIFF
--- a/MalibuTests/Specs/Response/ResponseHandlerSpec.swift
+++ b/MalibuTests/Specs/Response/ResponseHandlerSpec.swift
@@ -10,15 +10,16 @@ class ResponseHandlerSpec: QuickSpec {
       var handler: ResponseHandler!
       var data: Data!
       var response: HTTPURLResponse!
+      var urlRequest: URLRequest!
 
       beforeEach {
-        let urlRequest = try! TestService.showPost(id: 1).request.toUrlRequest()
+        urlRequest = try! TestService.showPost(id: 1).request.toUrlRequest()
         let networkPromise = NetworkPromise()
         data = "test".data(using: String.Encoding.utf32)
         response = HTTPURLResponse(
           url: urlRequest.url!, statusCode: 200, httpVersion: "HTTP/2.0", headerFields: nil
         )
-        handler = ResponseHandler(urlRequest: urlRequest, networkPromise: networkPromise)
+        handler = ResponseHandler(networkPromise: networkPromise)
       }
 
       describe("#handle") {
@@ -31,7 +32,7 @@ class ResponseHandlerSpec: QuickSpec {
               expectation.fulfill()
             })
 
-            handler.handle(data: data, urlResponse: nil, error: nil)
+            handler.handle(urlRequest: urlRequest, data: data, urlResponse: nil, error: nil)
             self.waitForExpectations(timeout: 4.0, handler:nil)
           }
         }
@@ -46,6 +47,7 @@ class ResponseHandlerSpec: QuickSpec {
             })
 
             handler.handle(
+              urlRequest: urlRequest,
               data: data,
               urlResponse: response,
               error: NetworkError.jsonDictionarySerializationFailed
@@ -63,7 +65,7 @@ class ResponseHandlerSpec: QuickSpec {
               expectation.fulfill()
             })
 
-            handler.handle(data: nil, urlResponse: response, error: nil)
+            handler.handle(urlRequest: urlRequest, data: nil, urlResponse: response, error: nil)
             self.waitForExpectations(timeout: 4.0, handler:nil)
           }
         }
@@ -74,13 +76,13 @@ class ResponseHandlerSpec: QuickSpec {
 
             handler.networkPromise.done({ result in
               expect(result.data).to(equal(data))
-              expect(result.request).to(equal(handler.urlRequest))
+              expect(result.request).to(equal(urlRequest))
               expect(result.response).to(equal(response))
 
               expectation.fulfill()
             })
 
-            handler.handle(data: data, urlResponse: response, error: nil)
+            handler.handle(urlRequest: urlRequest, data: data, urlResponse: response, error: nil)
             self.waitForExpectations(timeout: 4.0, handler:nil)
           }
         }

--- a/Sources/Operation/ConcurrentOperation.swift
+++ b/Sources/Operation/ConcurrentOperation.swift
@@ -19,7 +19,8 @@ class ConcurrentOperation: Operation {
     }
   }
 
-  var handleResponse: ((Data?, URLResponse?, Error?) -> Void)?
+  var handleResponse: ((URLRequest?, Data?, URLResponse?, Error?) -> Void)?
+  var makeUrlRequest: (() throws -> URLRequest)?
 
   override var isAsynchronous: Bool {
     return true
@@ -48,5 +49,12 @@ class ConcurrentOperation: Operation {
 
   func execute() {
     state = .Executing
+  }
+
+  func extractUrlRequest() throws -> URLRequest {
+    guard let makeUrlRequest = makeUrlRequest else {
+      throw NetworkError.invalidRequestURL
+    }
+    return try makeUrlRequest()
   }
 }

--- a/Sources/Operation/DataOperation.swift
+++ b/Sources/Operation/DataOperation.swift
@@ -2,25 +2,28 @@ import Foundation
 
 final class DataOperation: ConcurrentOperation {
   private let session: URLSession
-  private let urlRequest: URLRequest
   private var task: URLSessionDataTask?
 
   // MARK: - Initialization
 
-  init(session: URLSession, urlRequest: URLRequest) {
+  init(session: URLSession) {
     self.session = session
-    self.urlRequest = urlRequest
   }
 
   // MARK: - Operation
 
   override func execute() {
-    task = session.dataTask(with: urlRequest, completionHandler: { [weak self] (data, urlResponse, error) in
-      self?.handleResponse?(data, urlResponse, error)
-      self?.state = .Finished
-    })
+    do {
+      let urlRequest = try extractUrlRequest()
+      task = session.dataTask(with: urlRequest, completionHandler: { [weak self] (data, urlResponse, error) in
+        self?.handleResponse?(urlRequest, data, urlResponse, error)
+        self?.state = .Finished
+      })
 
-    task?.resume()
+      task?.resume()
+    } catch {
+      handleResponse?(nil, nil, nil, error)
+    }
   }
 
   override func cancel() {

--- a/Sources/Operation/MockOperation.swift
+++ b/Sources/Operation/MockOperation.swift
@@ -2,24 +2,27 @@ import Foundation
 
 final class MockOperation: ConcurrentOperation {
   private let mock: Mock
-  private let urlRequest: URLRequest
   private let delay: TimeInterval
 
   // MARK: - Initialization
 
-  init(mock: Mock, urlRequest: URLRequest, delay: TimeInterval = 0.0) {
+  init(mock: Mock, delay: TimeInterval = 0.0) {
     self.mock = mock
-    self.urlRequest = urlRequest
     self.delay = delay
   }
 
   // MARK: - Operation
 
   override func execute() {
-    let when = DispatchTime.now() + delay
-    DispatchQueue.main.asyncAfter(deadline: when) { [weak self] in
-      self?.handleResponse?(self?.mock.data, self?.mock.httpResponse, self?.mock.error)
-      self?.state = .Finished
+    do {
+      let urlRequest = try extractUrlRequest()
+      let when = DispatchTime.now() + delay
+      DispatchQueue.main.asyncAfter(deadline: when) { [weak self] in
+        self?.handleResponse?(urlRequest, self?.mock.data, self?.mock.httpResponse, self?.mock.error)
+        self?.state = .Finished
+      }
+    } catch {
+      handleResponse?(nil, nil, nil, error)
     }
   }
 

--- a/Sources/Response/ResponseHandler.swift
+++ b/Sources/Response/ResponseHandler.swift
@@ -2,14 +2,18 @@ import Foundation
 import When
 
 struct ResponseHandler {
-  let urlRequest: URLRequest
   let networkPromise: NetworkPromise
 }
 
 extension ResponseHandler {
-  func handle(data: Data?, urlResponse: URLResponse?, error: Error?) {
+  func handle(urlRequest: URLRequest?, data: Data?, urlResponse: URLResponse?, error: Error?) {
     if let error = error {
       networkPromise.reject(error)
+      return
+    }
+
+    guard let urlRequest = urlRequest else {
+      networkPromise.reject(NetworkError.invalidRequestURL)
       return
     }
 


### PR DESCRIPTION
To have all the headers up to date it makes sense to create `URLRequest` in operation `execute` method.