### PR TITLE
Update dependencies to get new version of When

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
 disabled_rules:
   - type_name
+  - identifier_name
 
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
-github "Quick/Nimble" "v6.0.1"
-github "Quick/Quick" "v1.0.0"
-github "vadymmarkov/When" "2.0.0"
+github "Quick/Nimble" "v7.0.0"
+github "Quick/Quick" "v1.1.0"
+github "ReactiveX/RxSwift" "3.5.0"
+github "vadymmarkov/When" "2.3.3"

--- a/Sources/Request/Ride.swift
+++ b/Sources/Request/Ride.swift
@@ -10,7 +10,7 @@ public final class Ride: Promise<Wave> {
     super.init()
   }
 
-  public func cancel() {
+  open override func cancel() {
     operation?.cancel()
     operation = nil
   }


### PR DESCRIPTION
Requires adding `open override` to `Ride.cancel()` and adding a SwiftLint rule exception to not cause a build error due to uppercased enum cases. This is done to not have to break the public API.

Note that this PR is targeting a `4.1.1` update release, not `master`.