### PR TITLE
Fix: construct request URL with query parameters

### DIFF
--- a/MalibuTests/Specs/Request/RequestSpec.swift
+++ b/MalibuTests/Specs/Request/RequestSpec.swift
@@ -98,6 +98,17 @@ class RequestSpec: QuickSpec {
             }
           }
 
+          context("with base URL without slash and query parameters") {
+            it("does not throw an error and returns created URLRequest") {
+              request = Request.post("about?q=1")
+
+              expect {
+                urlRequest = try request.toUrlRequest(baseUrl: "http://api.loc")
+                }.toNot(throwError())
+              expect(urlRequest.url?.absoluteString).to(equal("http://api.loc/about?q=1"))
+            }
+          }
+
           context("with additional headers") {
             it("returns created URLRequest with new header added") {
               let headers = ["foo": "bar", "key": "bar"]

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -287,12 +287,17 @@ public extension Request {
     let url: URL?
 
     if let baseUrl = baseUrl {
+      var base = baseUrl.urlString
+      if !base.hasSuffix("/") {
+        base.append("/")
+      }
+
       var path = resource.urlString
       if path.hasPrefix("/") {
         path.remove(at: path.startIndex)
       }
 
-      url = URL(string: baseUrl.urlString)?.appendingPathComponent(path)
+      url = URL(string: "\(base)\(path)")
     } else {
       url = URL(string: resource.urlString)
     }


### PR DESCRIPTION
This bug was introduced in https://github.com/hyperoslo/Malibu/pull/57. Apparently `appendingPathComponent` applies URL percent encoding, but we don't want to do that when a request is built using query parameters:
```swift
Request.get("search?q=text")
```
