### PR TITLE
Tiny improvement to the request builder

### DIFF
--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -202,14 +202,15 @@ public extension Request {
                     additionalHeaders: [String: String] = [:]) throws -> URLRequest {
     let prefix = baseUrl?.urlString ?? ""
 
-    let requestUrl: URL = try {
-        if let resourceUrl = resource as? URL, parameters.isEmpty {
+    let url: URL = try {
+        if let resourceUrl = resource as? URL {
             return resourceUrl
         } else {
-            let url = try concatURL(baseUrl: baseUrl?.urlString)
-            return try buildUrl(from: url)
+            return try concatURL(baseUrl: baseUrl?.urlString)
         }
     }()
+    
+    let requestUrl = try buildUrl(from: url)
     var request = URLRequest(url: requestUrl)
 
     request.httpMethod = method.rawValue

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -203,7 +203,13 @@ public extension Request {
     let prefix = baseUrl?.urlString ?? ""
     let url = try concatURL(baseUrl: baseUrl?.urlString)
 
-    let requestUrl = try buildUrl(from: url)
+    let requestUrl: URL = try {
+        if let resourceUrl = resource as? URL {
+            return resourceUrl
+        } else {
+            return try buildUrl(from: url)
+        }
+    }()
     var request = URLRequest(url: requestUrl)
 
     request.httpMethod = method.rawValue

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -201,12 +201,12 @@ public extension Request {
   func toUrlRequest(baseUrl: URLStringConvertible? = nil,
                     additionalHeaders: [String: String] = [:]) throws -> URLRequest {
     let prefix = baseUrl?.urlString ?? ""
-    let url = try concatURL(baseUrl: baseUrl?.urlString)
 
     let requestUrl: URL = try {
         if let resourceUrl = resource as? URL, parameters.isEmpty {
             return resourceUrl
         } else {
+            let url = try concatURL(baseUrl: baseUrl?.urlString)
             return try buildUrl(from: url)
         }
     }()

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -204,7 +204,7 @@ public extension Request {
     let url = try concatURL(baseUrl: baseUrl?.urlString)
 
     let requestUrl: URL = try {
-        if let resourceUrl = resource as? URL {
+        if let resourceUrl = resource as? URL, parameters.isEmpty {
             return resourceUrl
         } else {
             return try buildUrl(from: url)


### PR DESCRIPTION
If the URL you are requesting is already a valid URL, Malibu shouldn't convert it to String and attempt to create a new URL object. 