### PR TITLE
Remove validation of 204 responses in .validate()

### DIFF
--- a/Sources/Response/ResponseValidation.swift
+++ b/Sources/Response/ResponseValidation.swift
@@ -21,6 +21,10 @@ public extension Promise where T: Response {
 
   public func validate() -> Promise<Response> {
     return validate(statusCodes: 200..<300).then({ response -> Response in
+      guard response.statusCode != 204 else {
+        return response
+      }
+
       let contentTypes: [String]
 
       if let accept = response.urlRequest.value(forHTTPHeaderField: "Accept") {


### PR DESCRIPTION
Right now, the default `.validate()` fails when receiving a HTTP 204 NO CONTENT response trough Express, as [Express strips away those fields when not needed](https://github.com/expressjs/express/blob/9375a9afa9d7baa814b454c7a6818a7471aaef00/lib/response.js#L192-L198).

If the maintainers agree, I'd like to remove 204 from the standard `.validate()` method in ResponseValidation.swift.

Edit: 
A more detailed explanation of why it doesn't work: If you set `application/json` as `Accept` and receive a 204, Express strips the `Content-Type` field making NSURLRequest do its best to guess the `Content-Type` itself, and as Express does `chunk = ''` on a 204, it assumes its `text/plain`. That obviously fails content type validation.