### PR TITLE
Not including When in built framework

### DIFF
--- a/Malibu.xcodeproj/project.pbxproj
+++ b/Malibu.xcodeproj/project.pbxproj
@@ -757,7 +757,6 @@
 				D5B2E89B1C3A780C00C0327D /* Frameworks */,
 				D5B2E89C1C3A780C00C0327D /* Headers */,
 				D5B2E89D1C3A780C00C0327D /* Resources */,
-				DAC92A281C83A35700F01940 /* Copy frameworks with Carthage */,
 				D55166851DA1860300AECB6E /* SwiftLint */,
 			);
 			buildRules = (
@@ -1050,21 +1049,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/Mac/When.framework",
-			);
-			name = "Copy frameworks with Carthage";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		DAC92A281C83A35700F01940 /* Copy frameworks with Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/When.framework",
 			);
 			name = "Copy frameworks with Carthage";
 			outputPaths = (


### PR DESCRIPTION
Related to #96.

Submitting a version built this way got rejected from the AppStore, so we remove the 'included' dependency from Malibu, to the main project, circumventing the issue